### PR TITLE
feat(dbops): gate direct Identity table retirement

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -168,7 +168,7 @@ go test ./internal/pkg/migration -run "TestJWKSSingleActiveMigrationMySQL" -v -c
 
 MySQL 8 workflow 使用同一脚本执行合成 backup → drop → restore → 数据断言，不接触生产数据，也不上传备份 artifact。
 
-历史表退役证据由 `scripts/dbops/legacy-retirement-preflight.sh`（`make db-retirement-preflight`）只读采集。手动执行 `db-ops.yml` 的 `status` 时会在普通数据库状态检查后运行 format v2 预检，并要求调用者通过 `image_sha` 记录当前生产镜像；定时备份、`backup` 和 `restore` 不运行该预检。脚本不执行删表或数据修复，只输出 migration、精确行数、结构指纹、Performance Schema 生命周期/I/O、依赖计数、旧表到 canonical 表的聚合对账和逐表 eligibility；零 I/O 不能脱离证据窗口解释为“可删除”。
+历史表退役证据由 `scripts/dbops/legacy-retirement-preflight.sh`（`make db-retirement-preflight`）只读采集。手动执行 `db-ops.yml` 的 `status` 时会在普通数据库状态检查后运行 format v2 预检，并要求调用者通过 `image_sha` 记录当前生产镜像；`retirement_scope` 可选择 `identity/schema_version/platform/authn/all`，发布时只运行当前批次，避免无关大表对账占用窗口。定时备份、`backup` 和 `restore` 不运行该预检。脚本不执行删表或数据修复，只输出 migration、精确行数、结构指纹、列契约、Performance Schema 生命周期/I/O、依赖计数、旧表到 canonical 表的聚合对账和逐表 eligibility；零 I/O 不能脱离证据窗口解释为“可删除”。
 
 ## server-check.yml
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -167,7 +167,7 @@ go test ./internal/pkg/migration -run "TestJWKSSingleActiveMigrationMySQL" -v -c
 
 MySQL 8 workflow 使用同一脚本执行合成 backup → drop → restore → 数据断言，不接触生产数据，也不上传备份 artifact。
 
-历史表退役证据由 `scripts/dbops/legacy-retirement-preflight.sh`（`make db-retirement-preflight`）只读采集。它不是 `db-ops.yml` 的自动操作，不执行删表或数据修复；运行者必须显式记录环境和 image SHA。脚本只输出 migration、表级元数据、Performance Schema 生命周期/I/O、依赖计数和旧表到 canonical 表的对账摘要，零 I/O 不能脱离完整观察窗口解释为“可删除”。
+历史表退役证据由 `scripts/dbops/legacy-retirement-preflight.sh`（`make db-retirement-preflight`）只读采集。手动执行 `db-ops.yml` 的 `status` 时会在普通数据库状态检查后运行 format v2 预检，并要求调用者通过 `image_sha` 记录当前生产镜像；定时备份、`backup` 和 `restore` 不运行该预检。脚本不执行删表或数据修复，只输出 migration、精确行数、结构指纹、Performance Schema 生命周期/I/O、依赖计数、旧表到 canonical 表的聚合对账和逐表 eligibility；零 I/O 不能脱离证据窗口解释为“可删除”。
 
 ## server-check.yml
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -155,7 +155,8 @@ go test ./internal/pkg/migration -run "TestJWKSSingleActiveMigrationMySQL" -v -c
 
 安全约束：
 
-- 生产宿主机必须预先安装官方 MySQL 8.x `mysql` 与 `mysqldump`；定时 workflow 只校验，不执行包管理器。
+- 优先使用生产宿主机预装的官方 MySQL 8.x `mysql` 与 `mysqldump`；缺失时通过 passwordless sudo Docker 使用官方 `mysql:8.0` 客户端镜像，workflow 不执行包管理器安装。
+- 容器客户端仍只挂载临时 `0600` defaults file，执行结束即删除容器和临时 wrapper；镜像拉取失败或 Docker 不可用时 fail closed。
 - 三个 job checkout 仓库后统一通过 `scripts/dbops/database-operation.sh` 执行，不在 workflow 内复制数据库脚本。
 - 使用临时 MySQL defaults file 传递凭据，避免在命令行参数中直接出现密码。
 - 备份目录权限固定为 `0700`，defaults file 和最终备份固定为 `0600`。

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,6 @@
 # GitHub Actions Workflows
 
-最后检查日期：2026-07-24
+最后检查日期：2026-08-07
 
 本目录维护 IAM 仓库的 CI、生产部署、生产健康检查和数据库运维 workflow。当前生产部署目标以 serverB (`SVRB_*`) 为准；`SVRA_*` 仅作为部分 SSH secret 的迁移期 fallback。
 
@@ -11,7 +11,7 @@
 | `ci.yml` | 保留 | push `main`/`develop`、PR 到 `main`、手动 | lint、test、build、coverage、短期构建 artifact |
 | `cd.yml` | 保留 | `CI` 在 `main` 成功后自动；手动 | 发布镜像、生成部署包、部署 `iam-apiserver` 到 serverB |
 | `concurrency-tests.yml` | 保留 | 手动；相关 MySQL/测试路径变更时 push/PR 到 `main` | MySQL-backed 并发仓储测试 |
-| `db-ops.yml` | 保留，已移除 `migrate` | 每天 17:00 UTC；手动 `backup`/`restore`/`status` | 数据库备份、恢复、状态检查 |
+| `db-ops.yml` | 保留，已移除通用 `migrate` | 每天 17:00 UTC；手动数据库操作 | 数据库备份、恢复、状态检查及受控遗留表退役 |
 | `server-check.yml` | 保留 | 每 30 分钟；手动 | 生产容器、内部健康检查、依赖连通性 |
 | `test-ssh.yml` | 保留 | 手动 | 生产主机 SSH 和基础环境诊断 |
 
@@ -139,6 +139,8 @@ go test ./internal/pkg/migration -run "TestJWKSSingleActiveMigrationMySQL" -v -c
 - `backup`: 备份 MySQL，保留最近 3 份。
 - `restore`: 从 `iam_backup_YYYYMMDD_HHMMSS.sql.gz` 恢复。
 - `status`: 只输出 MySQL 客户端版本、连接状态、库总大小、表数量、备份数量和最新备份时间。
+- `retire-identity-dry-run`: 校验版本 18 clean、指定备份新鲜且完整、两张旧表同时存在及数据库对象零依赖，不写数据库。
+- `retire-identity-apply`: 在相同门禁和生产 environment 下，要求确认令牌 `RETIRE_CHILDREN_GUARDIANSHIPS`，用最终一条 DROP 同时删除 `children/guardianships`。
 
 已废弃：
 
@@ -157,7 +159,7 @@ go test ./internal/pkg/migration -run "TestJWKSSingleActiveMigrationMySQL" -v -c
 
 - 优先使用生产宿主机预装的官方 MySQL 8.x `mysql` 与 `mysqldump`；缺失时通过 passwordless sudo Docker 使用官方 `mysql:8.0` 客户端镜像，workflow 不执行包管理器安装。
 - 容器客户端仍只挂载临时 `0600` defaults file，执行结束即删除容器和临时 wrapper；镜像拉取失败或 Docker 不可用时 fail closed。
-- 三个 job checkout 仓库后统一通过 `scripts/dbops/database-operation.sh` 执行，不在 workflow 内复制数据库脚本。
+- 四个 job checkout 仓库后统一通过 `scripts/dbops/database-operation.sh` 执行，不在 workflow 内复制数据库脚本。
 - 使用临时 MySQL defaults file 传递凭据，避免在命令行参数中直接出现密码。
 - 备份目录权限固定为 `0700`，defaults file 和最终备份固定为 `0600`。
 - dump 流式写入临时 gzip，只有非空且 `gzip -t` 成功后才原子改名；失败不留下最终文件。
@@ -165,8 +167,9 @@ go test ./internal/pkg/migration -run "TestJWKSSingleActiveMigrationMySQL" -v -c
 - `restore` 只接受 `iam_backup_YYYYMMDD_HHMMSS.sql.gz` 精确格式的备份文件名。
 - restore 拒绝路径分隔符、符号链接、缺失文件和损坏 gzip；不会自动触发生产恢复。
 - `mysqldump`/`mysql` 的原始 stderr 不进入工作流输出，避免 SQL、地址或凭据泄露。
+- Identity 直接退役是一次性例外：业务所有者已明确放弃旧表到 canonical 表的数据对账，脚本不会写 `profiles/profile_links`；它仍要求指定两小时内的完整备份、`version=18, dirty=0`、零数据库对象依赖和显式确认令牌。删除后由 `000019` 幂等登记版本 19。
 
-MySQL 8 workflow 使用同一脚本执行合成 backup → drop → restore → 数据断言，不接触生产数据，也不上传备份 artifact。
+MySQL 8 workflow 使用同一脚本执行合成 backup → drop → restore → Identity dry-run/apply → 数据断言，不接触生产数据，也不上传备份 artifact。
 
 历史表退役证据由 `scripts/dbops/legacy-retirement-preflight.sh`（`make db-retirement-preflight`）只读采集。手动执行 `db-ops.yml` 的 `status` 时会在普通数据库状态检查后运行 format v2 预检，并要求调用者通过 `image_sha` 记录当前生产镜像；`retirement_scope` 可选择 `identity/schema_version/platform/authn/all`，发布时只运行当前批次，避免无关大表对账占用窗口。定时备份、`backup` 和 `restore` 不运行该预检。脚本不执行删表或数据修复，只输出 migration、精确行数、结构指纹、列契约、Performance Schema 生命周期/I/O、依赖计数、旧表到 canonical 表的聚合对账和逐表 eligibility；零 I/O 不能脱离证据窗口解释为“可删除”。
 

--- a/.github/workflows/concurrency-tests.yml
+++ b/.github/workflows/concurrency-tests.yml
@@ -159,7 +159,7 @@ jobs:
             2>&1 | tee test-artifacts/identity-migration-tests.txt
           exit "${PIPESTATUS[0]}"
 
-      - name: Verify database backup and restore script with MySQL 8
+      - name: Verify database backup, restore, and Identity retirement with MySQL 8
         env:
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
@@ -173,7 +173,7 @@ jobs:
           mysql --host="$MYSQL_HOST" --port="$MYSQL_PORT" --user="$MYSQL_USERNAME" \
             -e 'DROP DATABASE IF EXISTS iam_dbops_fixture; CREATE DATABASE iam_dbops_fixture CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
           mysql --host="$MYSQL_HOST" --port="$MYSQL_PORT" --user="$MYSQL_USERNAME" iam_dbops_fixture \
-            -e 'CREATE TABLE restore_fixture (id BIGINT PRIMARY KEY, value VARCHAR(32) NOT NULL); INSERT INTO restore_fixture VALUES (1, "restored");'
+            -e 'CREATE TABLE restore_fixture (id BIGINT PRIMARY KEY, value VARCHAR(32) NOT NULL); INSERT INTO restore_fixture VALUES (1, "restored"); CREATE TABLE schema_migrations (version BIGINT NOT NULL, dirty BOOLEAN NOT NULL); INSERT INTO schema_migrations VALUES (18, 0); CREATE TABLE children (id BIGINT PRIMARY KEY); INSERT INTO children VALUES (1), (2); CREATE TABLE guardianships (id BIGINT PRIMARY KEY); INSERT INTO guardianships VALUES (11), (12), (13);'
 
           IAM_DB_OPS_OPERATION=backup scripts/dbops/database-operation.sh
           backup_name="$(find "$IAM_DB_OPS_BACKUP_DIR" -maxdepth 1 -type f -name 'iam_backup_*.sql.gz' -exec basename {} \;)"
@@ -185,6 +185,15 @@ jobs:
           restored="$(mysql --host="$MYSQL_HOST" --port="$MYSQL_PORT" --user="$MYSQL_USERNAME" --batch --skip-column-names iam_dbops_fixture -e 'SELECT value FROM restore_fixture WHERE id = 1;')"
           test "$restored" = "restored"
           IAM_DB_OPS_OPERATION=status scripts/dbops/database-operation.sh
+          IAM_DB_OPS_OPERATION=retire-identity-dry-run IAM_DB_OPS_BACKUP_NAME="$backup_name" \
+            scripts/dbops/database-operation.sh
+          IAM_DB_OPS_OPERATION=retire-identity-apply IAM_DB_OPS_BACKUP_NAME="$backup_name" \
+            IAM_DB_OPS_CONFIRMATION=RETIRE_CHILDREN_GUARDIANSHIPS \
+            scripts/dbops/database-operation.sh
+          remaining="$(mysql --host="$MYSQL_HOST" --port="$MYSQL_PORT" --user="$MYSQL_USERNAME" \
+            --batch --skip-column-names iam_dbops_fixture \
+            -e "SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('children', 'guardianships');")"
+          test "$remaining" = "0"
 
       - name: Upload test logs on failure
         if: failure()

--- a/.github/workflows/db-ops.yml
+++ b/.github/workflows/db-ops.yml
@@ -1,8 +1,9 @@
 name: Database Operations
 
 # Production host contract:
-# - mysql and mysqldump are pre-provisioned official MySQL 8.x clients.
-# - the workflow validates the contract but never installs host packages.
+# - prefer pre-provisioned official MySQL 8.x clients.
+# - if absent, use the official mysql:8.0 image through passwordless sudo Docker.
+# - the workflow never installs host packages.
 # - credentials are passed through a temporary 0600 defaults file by the script.
 
 on:
@@ -44,6 +45,7 @@ jobs:
         uses: appleboy/ssh-action@v1.2.5
         env:
           IAM_DB_OPS_OPERATION: backup
+          IAM_DB_OPS_ALLOW_DOCKER_CLIENT: "1"
           MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
           MYSQL_PORT: ${{ secrets.MYSQL_PORT || 3306 }}
           MYSQL_USERNAME: ${{ secrets.MYSQL_USERNAME }}
@@ -54,7 +56,7 @@ jobs:
           username: ${{ vars.SVRB_USERNAME || vars.SVRA_USERNAME }}
           key: ${{ secrets.SVRB_SSH_KEY || secrets.SVRA_SSH_KEY }}
           port: ${{ vars.SVRB_SSH_PORT || vars.SVRA_SSH_PORT || 22 }}
-          envs: IAM_DB_OPS_OPERATION,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
+          envs: IAM_DB_OPS_OPERATION,IAM_DB_OPS_ALLOW_DOCKER_CLIENT,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
           script_path: scripts/dbops/database-operation.sh
 
   db-restore:
@@ -70,6 +72,7 @@ jobs:
         uses: appleboy/ssh-action@v1.2.5
         env:
           IAM_DB_OPS_OPERATION: restore
+          IAM_DB_OPS_ALLOW_DOCKER_CLIENT: "1"
           IAM_DB_OPS_BACKUP_NAME: ${{ github.event.inputs.backup_name }}
           MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
           MYSQL_PORT: ${{ secrets.MYSQL_PORT || 3306 }}
@@ -81,7 +84,7 @@ jobs:
           username: ${{ vars.SVRB_USERNAME || vars.SVRA_USERNAME }}
           key: ${{ secrets.SVRB_SSH_KEY || secrets.SVRA_SSH_KEY }}
           port: ${{ vars.SVRB_SSH_PORT || vars.SVRA_SSH_PORT || 22 }}
-          envs: IAM_DB_OPS_OPERATION,IAM_DB_OPS_BACKUP_NAME,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
+          envs: IAM_DB_OPS_OPERATION,IAM_DB_OPS_BACKUP_NAME,IAM_DB_OPS_ALLOW_DOCKER_CLIENT,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
           script_path: scripts/dbops/database-operation.sh
 
   db-status:
@@ -97,6 +100,7 @@ jobs:
         uses: appleboy/ssh-action@v1.2.5
         env:
           IAM_DB_OPS_OPERATION: status
+          IAM_DB_OPS_ALLOW_DOCKER_CLIENT: "1"
           MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
           MYSQL_PORT: ${{ secrets.MYSQL_PORT || 3306 }}
           MYSQL_USERNAME: ${{ secrets.MYSQL_USERNAME }}
@@ -107,13 +111,14 @@ jobs:
           username: ${{ vars.SVRB_USERNAME || vars.SVRA_USERNAME }}
           key: ${{ secrets.SVRB_SSH_KEY || secrets.SVRA_SSH_KEY }}
           port: ${{ vars.SVRB_SSH_PORT || vars.SVRA_SSH_PORT || 22 }}
-          envs: IAM_DB_OPS_OPERATION,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
+          envs: IAM_DB_OPS_OPERATION,IAM_DB_OPS_ALLOW_DOCKER_CLIENT,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
           script_path: scripts/dbops/database-operation.sh
 
       - name: Run Legacy Retirement Preflight
         uses: appleboy/ssh-action@v1.2.5
         env:
           IAM_RETIREMENT_ENVIRONMENT: production
+          IAM_RETIREMENT_ALLOW_DOCKER_CLIENT: "1"
           IAM_RETIREMENT_COMMIT_SHA: ${{ github.sha }}
           IAM_RETIREMENT_IMAGE_SHA: ${{ github.event.inputs.image_sha || 'unknown' }}
           MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
@@ -126,5 +131,5 @@ jobs:
           username: ${{ vars.SVRB_USERNAME || vars.SVRA_USERNAME }}
           key: ${{ secrets.SVRB_SSH_KEY || secrets.SVRA_SSH_KEY }}
           port: ${{ vars.SVRB_SSH_PORT || vars.SVRA_SSH_PORT || 22 }}
-          envs: IAM_RETIREMENT_ENVIRONMENT,IAM_RETIREMENT_COMMIT_SHA,IAM_RETIREMENT_IMAGE_SHA,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
+          envs: IAM_RETIREMENT_ENVIRONMENT,IAM_RETIREMENT_ALLOW_DOCKER_CLIENT,IAM_RETIREMENT_COMMIT_SHA,IAM_RETIREMENT_IMAGE_SHA,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
           script_path: scripts/dbops/legacy-retirement-preflight.sh

--- a/.github/workflows/db-ops.yml
+++ b/.github/workflows/db-ops.yml
@@ -25,6 +25,17 @@ on:
         description: Currently deployed IAM image Git SHA, required for retirement preflight evidence
         required: false
         type: string
+      retirement_scope:
+        description: Retirement preflight scope for status
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - identity
+          - schema_version
+          - platform
+          - authn
   schedule:
     - cron: '0 17 * * *'  # Daily 17:00 UTC / 01:00 Asia-Shanghai
 
@@ -91,7 +102,7 @@ jobs:
     name: Database Status
     if: github.event.inputs.operation == 'status'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -121,6 +132,7 @@ jobs:
           IAM_RETIREMENT_ALLOW_DOCKER_CLIENT: "1"
           IAM_RETIREMENT_COMMIT_SHA: ${{ github.sha }}
           IAM_RETIREMENT_IMAGE_SHA: ${{ github.event.inputs.image_sha || 'unknown' }}
+          IAM_RETIREMENT_SCOPE: ${{ github.event.inputs.retirement_scope || 'all' }}
           MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
           MYSQL_PORT: ${{ secrets.MYSQL_PORT || 3306 }}
           MYSQL_USERNAME: ${{ secrets.MYSQL_USERNAME }}
@@ -131,5 +143,5 @@ jobs:
           username: ${{ vars.SVRB_USERNAME || vars.SVRA_USERNAME }}
           key: ${{ secrets.SVRB_SSH_KEY || secrets.SVRA_SSH_KEY }}
           port: ${{ vars.SVRB_SSH_PORT || vars.SVRA_SSH_PORT || 22 }}
-          envs: IAM_RETIREMENT_ENVIRONMENT,IAM_RETIREMENT_ALLOW_DOCKER_CLIENT,IAM_RETIREMENT_COMMIT_SHA,IAM_RETIREMENT_IMAGE_SHA,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
+          envs: IAM_RETIREMENT_ENVIRONMENT,IAM_RETIREMENT_ALLOW_DOCKER_CLIENT,IAM_RETIREMENT_COMMIT_SHA,IAM_RETIREMENT_IMAGE_SHA,IAM_RETIREMENT_SCOPE,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
           script_path: scripts/dbops/legacy-retirement-preflight.sh

--- a/.github/workflows/db-ops.yml
+++ b/.github/workflows/db-ops.yml
@@ -17,6 +17,8 @@ on:
           - backup
           - restore
           - status
+          - retire-identity-dry-run
+          - retire-identity-apply
       backup_name:
         description: Backup name, required for restore
         required: false
@@ -36,6 +38,10 @@ on:
           - schema_version
           - platform
           - authn
+      confirmation:
+        description: Exact destructive-operation confirmation token; required for apply only
+        required: false
+        type: string
   schedule:
     - cron: '0 17 * * *'  # Daily 17:00 UTC / 01:00 Asia-Shanghai
 
@@ -145,3 +151,37 @@ jobs:
           port: ${{ vars.SVRB_SSH_PORT || vars.SVRA_SSH_PORT || 22 }}
           envs: IAM_RETIREMENT_ENVIRONMENT,IAM_RETIREMENT_ALLOW_DOCKER_CLIENT,IAM_RETIREMENT_COMMIT_SHA,IAM_RETIREMENT_IMAGE_SHA,IAM_RETIREMENT_SCOPE,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
           script_path: scripts/dbops/legacy-retirement-preflight.sh
+
+  db-identity-retirement:
+    name: Retire Legacy Identity Tables
+    if: github.event.inputs.operation == 'retire-identity-dry-run' || github.event.inputs.operation == 'retire-identity-apply'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: production
+    concurrency:
+      group: iam-production-identity-retirement
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate or retire children and guardianships
+        uses: appleboy/ssh-action@v1.2.5
+        env:
+          IAM_DB_OPS_OPERATION: ${{ github.event.inputs.operation }}
+          IAM_DB_OPS_ALLOW_DOCKER_CLIENT: "1"
+          IAM_DB_OPS_BACKUP_NAME: ${{ github.event.inputs.backup_name }}
+          IAM_DB_OPS_CONFIRMATION: ${{ github.event.inputs.confirmation }}
+          MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
+          MYSQL_PORT: ${{ secrets.MYSQL_PORT || 3306 }}
+          MYSQL_USERNAME: ${{ secrets.MYSQL_USERNAME }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+          MYSQL_DBNAME: ${{ secrets.MYSQL_DBNAME }}
+        with:
+          host: ${{ vars.SVRB_PUBLIC_HOST || secrets.SVRB_PUBLIC_HOST || vars.SVRB_HOST || vars.SVRA_HOST }}
+          username: ${{ vars.SVRB_USERNAME || vars.SVRA_USERNAME }}
+          key: ${{ secrets.SVRB_SSH_KEY || secrets.SVRA_SSH_KEY }}
+          port: ${{ vars.SVRB_SSH_PORT || vars.SVRA_SSH_PORT || 22 }}
+          envs: IAM_DB_OPS_OPERATION,IAM_DB_OPS_ALLOW_DOCKER_CLIENT,IAM_DB_OPS_BACKUP_NAME,IAM_DB_OPS_CONFIRMATION,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
+          script_path: scripts/dbops/database-operation.sh

--- a/.github/workflows/db-ops.yml
+++ b/.github/workflows/db-ops.yml
@@ -20,6 +20,10 @@ on:
         description: Backup name, required for restore
         required: false
         type: string
+      image_sha:
+        description: Currently deployed IAM image Git SHA, required for retirement preflight evidence
+        required: false
+        type: string
   schedule:
     - cron: '0 17 * * *'  # Daily 17:00 UTC / 01:00 Asia-Shanghai
 
@@ -105,3 +109,22 @@ jobs:
           port: ${{ vars.SVRB_SSH_PORT || vars.SVRA_SSH_PORT || 22 }}
           envs: IAM_DB_OPS_OPERATION,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
           script_path: scripts/dbops/database-operation.sh
+
+      - name: Run Legacy Retirement Preflight
+        uses: appleboy/ssh-action@v1.2.5
+        env:
+          IAM_RETIREMENT_ENVIRONMENT: production
+          IAM_RETIREMENT_COMMIT_SHA: ${{ github.sha }}
+          IAM_RETIREMENT_IMAGE_SHA: ${{ github.event.inputs.image_sha || 'unknown' }}
+          MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
+          MYSQL_PORT: ${{ secrets.MYSQL_PORT || 3306 }}
+          MYSQL_USERNAME: ${{ secrets.MYSQL_USERNAME }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+          MYSQL_DBNAME: ${{ secrets.MYSQL_DBNAME }}
+        with:
+          host: ${{ vars.SVRB_PUBLIC_HOST || secrets.SVRB_PUBLIC_HOST || vars.SVRB_HOST || vars.SVRA_HOST }}
+          username: ${{ vars.SVRB_USERNAME || vars.SVRA_USERNAME }}
+          key: ${{ secrets.SVRB_SSH_KEY || secrets.SVRA_SSH_KEY }}
+          port: ${{ vars.SVRB_SSH_PORT || vars.SVRA_SSH_PORT || 22 }}
+          envs: IAM_RETIREMENT_ENVIRONMENT,IAM_RETIREMENT_COMMIT_SHA,IAM_RETIREMENT_IMAGE_SHA,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
+          script_path: scripts/dbops/legacy-retirement-preflight.sh

--- a/internal/pkg/migration/retire_legacy_identity_mysql_test.go
+++ b/internal/pkg/migration/retire_legacy_identity_mysql_test.go
@@ -113,7 +113,7 @@ CREATE TABLE children (
   deleted_by BIGINT UNSIGNED NOT NULL DEFAULT 0,
   version INT UNSIGNED NOT NULL DEFAULT 1,
   UNIQUE KEY uk_id_card (id_card)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 CREATE TABLE guardianships (
   id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
   user_id BIGINT UNSIGNED NOT NULL,
@@ -128,7 +128,7 @@ CREATE TABLE guardianships (
   updated_by BIGINT UNSIGNED NOT NULL DEFAULT 0,
   deleted_by BIGINT UNSIGNED NOT NULL DEFAULT 0,
   version INT UNSIGNED NOT NULL DEFAULT 1
-) ENGINE=InnoDB`); err != nil {
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`); err != nil {
 		t.Fatalf("create legacy Identity fixture: %v", err)
 	}
 }

--- a/scripts/check-docs-facts.py
+++ b/scripts/check-docs-facts.py
@@ -362,7 +362,13 @@ def check_database_operations_facts() -> None:
         fail("database workflow no longer routes all operations through the repository script")
     if workflow.count("script_path: scripts/dbops/legacy-retirement-preflight.sh") != 1:
         fail("database status no longer runs the checked-out retirement preflight exactly once")
-    for token in ("image_sha:", "IAM_RETIREMENT_IMAGE_SHA", "Run Legacy Retirement Preflight"):
+    for token in (
+        "image_sha:",
+        "IAM_RETIREMENT_IMAGE_SHA",
+        "Run Legacy Retirement Preflight",
+        "IAM_DB_OPS_ALLOW_DOCKER_CLIENT",
+        "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
+    ):
         if token not in workflow:
             fail(f"database status retirement preflight is missing {token}")
     for forbidden in ("apt-get", "apk add", "script: |", "SHOW TABLES"):
@@ -380,6 +386,8 @@ def check_database_operations_facts() -> None:
         "chmod 0700",
         "chmod 0600",
         "Ver 8\\.",
+        "IAM_DB_OPS_ALLOW_DOCKER_CLIENT",
+        "mysql:8.0",
     ):
         if token not in script:
             fail(f"database operation script is missing safety contract {token}")
@@ -399,6 +407,8 @@ def check_database_operations_facts() -> None:
         "invalid_supported_rows",
         "oauth_unmapped_rows",
         "unknown_credential_rows",
+        "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
+        "mysql:8.0",
     ):
         if token not in retirement:
             fail(f"legacy retirement preflight is missing safety contract {token}")

--- a/scripts/check-docs-facts.py
+++ b/scripts/check-docs-facts.py
@@ -368,6 +368,8 @@ def check_database_operations_facts() -> None:
         "Run Legacy Retirement Preflight",
         "IAM_DB_OPS_ALLOW_DOCKER_CLIENT",
         "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
+        "retirement_scope:",
+        "IAM_RETIREMENT_SCOPE",
     ):
         if token not in workflow:
             fail(f"database status retirement preflight is missing {token}")
@@ -409,6 +411,8 @@ def check_database_operations_facts() -> None:
         "unknown_credential_rows",
         "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
         "mysql:8.0",
+        "IAM_RETIREMENT_SCOPE",
+        "schema_contract",
     ):
         if token not in retirement:
             fail(f"legacy retirement preflight is missing safety contract {token}")

--- a/scripts/check-docs-facts.py
+++ b/scripts/check-docs-facts.py
@@ -358,7 +358,7 @@ def check_database_operations_facts() -> None:
         encoding="utf-8"
     )
 
-    if workflow.count("script_path: scripts/dbops/database-operation.sh") != 3:
+    if workflow.count("script_path: scripts/dbops/database-operation.sh") != 4:
         fail("database workflow no longer routes all operations through the repository script")
     if workflow.count("script_path: scripts/dbops/legacy-retirement-preflight.sh") != 1:
         fail("database status no longer runs the checked-out retirement preflight exactly once")
@@ -370,6 +370,9 @@ def check_database_operations_facts() -> None:
         "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
         "retirement_scope:",
         "IAM_RETIREMENT_SCOPE",
+        "retire-identity-dry-run",
+        "retire-identity-apply",
+        "IAM_DB_OPS_CONFIRMATION",
     ):
         if token not in workflow:
             fail(f"database status retirement preflight is missing {token}")
@@ -390,6 +393,9 @@ def check_database_operations_facts() -> None:
         "Ver 8\\.",
         "IAM_DB_OPS_ALLOW_DOCKER_CLIENT",
         "mysql:8.0",
+        "RETIRE_CHILDREN_GUARDIANSHIPS",
+        "DROP TABLE children, guardianships;",
+        "canonical_writes=0",
     ):
         if token not in script:
             fail(f"database operation script is missing safety contract {token}")
@@ -429,9 +435,11 @@ def check_database_operations_facts() -> None:
         if forbidden in retirement.upper():
             fail(f"legacy retirement preflight contains forbidden token {forbidden}")
     for token in (
-        "Verify database backup and restore script with MySQL 8",
+        "Verify database backup, restore, and Identity retirement with MySQL 8",
         "IAM_DB_OPS_OPERATION=backup",
         "IAM_DB_OPS_OPERATION=restore",
+        "IAM_DB_OPS_OPERATION=retire-identity-dry-run",
+        "IAM_DB_OPS_OPERATION=retire-identity-apply",
         "SELECT value FROM restore_fixture",
     ):
         if token not in integration:

--- a/scripts/check-docs-facts.py
+++ b/scripts/check-docs-facts.py
@@ -119,7 +119,6 @@ def check_migrations() -> None:
         if forbidden in retirement:
             fail(f"migration 000019 includes out-of-scope table {forbidden}")
 
-
 def check_database_schema_sources() -> None:
     retired_snapshot = ROOT / "configs/mysql/schema.sql"
     if retired_snapshot.exists():
@@ -139,8 +138,6 @@ def check_database_schema_sources() -> None:
     for forbidden in ("CREATE TABLE", "ALTER TABLE", "DROP TABLE"):
         if re.search(rf"(?im)^\s*{forbidden}\b", bootstrap):
             fail(f"bootstrap.sql contains schema-changing statement {forbidden}")
-
-
 def check_event_catalog() -> None:
     catalog = load_yaml("configs/events.yaml")
     topics = catalog.get("topics", {})
@@ -363,6 +360,11 @@ def check_database_operations_facts() -> None:
 
     if workflow.count("script_path: scripts/dbops/database-operation.sh") != 3:
         fail("database workflow no longer routes all operations through the repository script")
+    if workflow.count("script_path: scripts/dbops/legacy-retirement-preflight.sh") != 1:
+        fail("database status no longer runs the checked-out retirement preflight exactly once")
+    for token in ("image_sha:", "IAM_RETIREMENT_IMAGE_SHA", "Run Legacy Retirement Preflight"):
+        if token not in workflow:
+            fail(f"database status retirement preflight is missing {token}")
     for forbidden in ("apt-get", "apk add", "script: |", "SHOW TABLES"):
         if forbidden in workflow:
             fail(f"database workflow contains retired inline behavior {forbidden}")
@@ -382,6 +384,7 @@ def check_database_operations_facts() -> None:
         if token not in script:
             fail(f"database operation script is missing safety contract {token}")
     for token in (
+        "format_version=2",
         "query_mode=read_only_aggregate",
         "--defaults-extra-file=",
         "performance_schema.table_io_waits_summary_by_table",
@@ -390,6 +393,12 @@ def check_database_operations_facts() -> None:
         "guardianships_to_profile_links",
         "auth_accounts_to_login_identities",
         "legacy_credentials_to_authn",
+        "exact_rows",
+        "schema_signature",
+        "eligibility",
+        "invalid_supported_rows",
+        "oauth_unmapped_rows",
+        "unknown_credential_rows",
     ):
         if token not in retirement:
             fail(f"legacy retirement preflight is missing safety contract {token}")

--- a/scripts/dbops/database-operation.sh
+++ b/scripts/dbops/database-operation.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 OPERATION="${IAM_DB_OPS_OPERATION:-}"
 BACKUP_NAME="${IAM_DB_OPS_BACKUP_NAME:-}"
 BACKUP_DIR="${IAM_DB_OPS_BACKUP_DIR:-/opt/backups/iam/database}"
+CONFIRMATION="${IAM_DB_OPS_CONFIRMATION:-}"
+MAX_BACKUP_AGE_SECONDS="${IAM_DB_OPS_MAX_BACKUP_AGE_SECONDS:-7200}"
 MYSQL_BIN="${IAM_DB_OPS_MYSQL_BIN:-mysql}"
 MYSQLDUMP_BIN="${IAM_DB_OPS_MYSQLDUMP_BIN:-mysqldump}"
 TIMESTAMP_OVERRIDE="${IAM_DB_OPS_TIMESTAMP:-}"
@@ -16,6 +18,7 @@ PARTIAL_PATH=""
 ERROR_PATH=""
 MYSQL_CLIENT_VERSION=""
 CLIENT_WRAPPER_DIR=""
+SQL_PATH=""
 
 fail() {
   echo "database operation failed: $1" >&2
@@ -35,6 +38,9 @@ cleanup() {
   if [ -n "$CLIENT_WRAPPER_DIR" ]; then
     rm -f -- "$CLIENT_WRAPPER_DIR/mysql" "$CLIENT_WRAPPER_DIR/mysqldump"
     rmdir -- "$CLIENT_WRAPPER_DIR" 2>/dev/null || true
+  fi
+  if [ -n "$SQL_PATH" ]; then
+    rm -f -- "$SQL_PATH"
   fi
 }
 
@@ -120,7 +126,7 @@ require_value() {
 
 validate_configuration() {
   case "$OPERATION" in
-    backup|restore|status) ;;
+    backup|restore|status|retire-identity-dry-run|retire-identity-apply) ;;
     *) fail "unsupported operation"; return 1 ;;
   esac
 
@@ -135,6 +141,10 @@ validate_configuration() {
   fi
   if ! [[ "$MYSQL_DBNAME" =~ ^[A-Za-z0-9_]+$ ]]; then
     fail "database name is invalid"
+    return 1
+  fi
+  if ! [[ "$MAX_BACKUP_AGE_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+    fail "backup age limit is invalid"
     return 1
   fi
   if [[ "$BACKUP_DIR" != /* ]] || [ -L "$BACKUP_DIR" ]; then
@@ -262,6 +272,34 @@ validate_backup_name() {
   fi
 }
 
+validate_recent_backup() {
+  validate_backup_name || return 1
+  prepare_backup_directory || return 1
+
+  local source_path="$BACKUP_DIR/$BACKUP_NAME"
+  local modified_at now age
+  if [ -L "$source_path" ] || [ ! -f "$source_path" ]; then
+    fail "retirement backup file is unavailable"
+    return 1
+  fi
+  if [ ! -s "$source_path" ] || ! gzip -t "$source_path" 2>/dev/null; then
+    fail "retirement backup integrity validation failed"
+    return 1
+  fi
+  modified_at="$(stat -c %Y "$source_path" 2>/dev/null || stat -f %m "$source_path" 2>/dev/null || true)"
+  now="$(date +%s)"
+  if ! [[ "$modified_at" =~ ^[0-9]+$ ]] || ! [[ "$now" =~ ^[0-9]+$ ]] || [ "$now" -lt "$modified_at" ]; then
+    fail "retirement backup age is unavailable"
+    return 1
+  fi
+  age=$((now - modified_at))
+  if [ "$age" -gt "$MAX_BACKUP_AGE_SECONDS" ]; then
+    fail "retirement backup is stale"
+    return 1
+  fi
+  echo "identity retirement backup: result=valid age_seconds=$age max_age_seconds=$MAX_BACKUP_AGE_SECONDS"
+}
+
 restore_database() {
   require_mysql8_client "$MYSQL_BIN" mysql || return 1
   command -v gzip >/dev/null 2>&1 || { fail "gzip is unavailable"; return 1; }
@@ -312,6 +350,208 @@ database_status() {
   echo "database status: result=success mysql_client=$MYSQL_CLIENT_VERSION connection=success size_mb=$database_size tables=$table_count backups=$backup_count latest_backup=$latest_backup"
 }
 
+mysql_scalar() {
+  local sql="$1"
+  "$MYSQL_BIN" --defaults-extra-file="$MYSQL_DEFAULTS" --batch --skip-column-names --raw \
+    "$MYSQL_DBNAME" -e "$sql" 2>"$ERROR_PATH"
+}
+
+identity_retirement_dependency_count() {
+  mysql_scalar "SELECT
+    (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE
+      WHERE (TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('children', 'guardianships') AND REFERENCED_TABLE_NAME IS NOT NULL)
+         OR (REFERENCED_TABLE_SCHEMA = DATABASE() AND REFERENCED_TABLE_NAME IN ('children', 'guardianships')))
+    + (SELECT COUNT(*) FROM information_schema.TRIGGERS
+      WHERE TRIGGER_SCHEMA = DATABASE()
+        AND (EVENT_OBJECT_TABLE IN ('children', 'guardianships')
+          OR LOWER(ACTION_STATEMENT) REGEXP '(^|[^a-z0-9_])(children|guardianships)([^a-z0-9_]|$)'))
+    + (SELECT COUNT(*) FROM information_schema.VIEWS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND (VIEW_DEFINITION IS NULL
+          OR LOWER(VIEW_DEFINITION) REGEXP '(^|[^a-z0-9_])(children|guardianships)([^a-z0-9_]|$)'))
+    + (SELECT COUNT(*) FROM information_schema.ROUTINES
+      WHERE ROUTINE_SCHEMA = DATABASE()
+        AND (ROUTINE_DEFINITION IS NULL
+          OR LOWER(ROUTINE_DEFINITION) REGEXP '(^|[^a-z0-9_])(children|guardianships)([^a-z0-9_]|$)'))
+    + (SELECT COUNT(*) FROM information_schema.EVENTS
+      WHERE EVENT_SCHEMA = DATABASE()
+        AND (EVENT_DEFINITION IS NULL
+          OR LOWER(EVENT_DEFINITION) REGEXP '(^|[^a-z0-9_])(children|guardianships)([^a-z0-9_]|$)'));"
+}
+
+identity_retirement_gate() {
+  require_mysql8_client "$MYSQL_BIN" mysql || return 1
+  command -v gzip >/dev/null 2>&1 || { fail "gzip is unavailable"; return 1; }
+  validate_recent_backup || return 1
+  prepare_defaults_file
+  ERROR_PATH="$BACKUP_DIR/.iam_identity_retirement.error"
+
+  local migration_state table_state row_counts dependency_count
+  if ! migration_state="$(mysql_scalar "SELECT COALESCE(MAX(version), -1), COALESCE(MAX(dirty + 0), -1), COUNT(*) FROM schema_migrations;")"; then
+    fail "identity retirement migration state is unavailable"
+    return 1
+  fi
+  if [ "$migration_state" != $'18\t0\t1' ]; then
+    fail "identity retirement requires schema_migrations version 18 clean"
+    return 1
+  fi
+
+  if ! table_state="$(mysql_scalar "SELECT
+      COALESCE(SUM(TABLE_NAME = 'children' AND TABLE_TYPE = 'BASE TABLE'), 0),
+      COALESCE(SUM(TABLE_NAME = 'guardianships' AND TABLE_TYPE = 'BASE TABLE'), 0)
+    FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('children', 'guardianships');")"; then
+    fail "identity retirement table state is unavailable"
+    return 1
+  fi
+  if [ "$table_state" = $'0\t0' ]; then
+    echo "identity retirement gate: state=already_absent migration_version=18 dirty=0 reconciliation=waived_by_owner"
+    return 0
+  fi
+  if [ "$table_state" != $'1\t1' ]; then
+    fail "identity retirement found a partial legacy table state"
+    return 1
+  fi
+
+  if ! dependency_count="$(identity_retirement_dependency_count)" || ! [[ "$dependency_count" =~ ^[0-9]+$ ]]; then
+    fail "identity retirement dependency evidence is unavailable"
+    return 1
+  fi
+  if [ "$dependency_count" != "0" ]; then
+    fail "identity retirement database dependencies still exist"
+    return 1
+  fi
+  if ! row_counts="$(mysql_scalar "SELECT (SELECT COUNT(*) FROM children), (SELECT COUNT(*) FROM guardianships);")"; then
+    fail "identity retirement row counts are unavailable"
+    return 1
+  fi
+  if ! [[ "$row_counts" =~ ^[0-9]+$'\t'[0-9]+$ ]]; then
+    fail "identity retirement row counts are invalid"
+    return 1
+  fi
+
+  local children_rows guardianship_rows
+  IFS=$'\t' read -r children_rows guardianship_rows <<<"$row_counts"
+  echo "identity retirement gate: state=eligible migration_version=18 dirty=0 dependencies=0 children_rows=$children_rows guardianships_rows=$guardianship_rows action=direct_drop reconciliation=waived_by_owner"
+}
+
+retire_identity_tables() {
+  identity_retirement_gate || return 1
+  if [ "$OPERATION" = "retire-identity-dry-run" ]; then
+    echo "identity retirement completed: mode=dry-run result=success"
+    return 0
+  fi
+  if [ "$CONFIRMATION" != "RETIRE_CHILDREN_GUARDIANSHIPS" ]; then
+    fail "identity retirement confirmation is invalid"
+    return 1
+  fi
+
+  local table_state result
+  if ! table_state="$(mysql_scalar "SELECT
+      COALESCE(SUM(TABLE_NAME = 'children' AND TABLE_TYPE = 'BASE TABLE'), 0),
+      COALESCE(SUM(TABLE_NAME = 'guardianships' AND TABLE_TYPE = 'BASE TABLE'), 0)
+    FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('children', 'guardianships');")"; then
+    fail "identity retirement table state is unavailable"
+    return 1
+  fi
+  if [ "$table_state" = $'0\t0' ]; then
+    echo "identity retirement completed: mode=apply result=already_absent"
+    return 0
+  fi
+  if [ "$table_state" != $'1\t1' ]; then
+    fail "identity retirement found a partial legacy table state"
+    return 1
+  fi
+
+  SQL_PATH="$(mktemp "${TMPDIR:-/tmp}/iam-identity-retirement.XXXXXX.sql")"
+  chmod 0600 "$SQL_PATH"
+  cat >"$SQL_PATH" <<'SQL'
+SELECT GET_LOCK('iam_retire_children_guardianships', 0) INTO @iam_retirement_lock;
+
+DROP TEMPORARY TABLE IF EXISTS iam_identity_retirement_assertion;
+CREATE TEMPORARY TABLE iam_identity_retirement_assertion
+(
+    message VARCHAR(128) NOT NULL PRIMARY KEY
+);
+INSERT INTO iam_identity_retirement_assertion (message)
+VALUES ('identity retirement gate failed');
+INSERT INTO iam_identity_retirement_assertion (message)
+SELECT 'identity retirement gate failed'
+WHERE @iam_retirement_lock <> 1;
+
+LOCK TABLES children WRITE, guardianships WRITE, schema_migrations READ;
+
+SET @iam_migration_invalid = (
+    SELECT NOT (COUNT(*) = 1 AND MAX(version) = 18 AND MAX(dirty + 0) = 0)
+    FROM schema_migrations
+);
+INSERT INTO iam_identity_retirement_assertion (message)
+SELECT 'identity retirement gate failed'
+WHERE @iam_migration_invalid <> 0;
+
+SET @iam_retirement_pattern = '(^|[^a-z0-9_])(children|guardianships)([^a-z0-9_]|$)';
+SET @iam_retirement_dependencies = (
+      SELECT COUNT(*)
+      FROM information_schema.KEY_COLUMN_USAGE
+      WHERE (TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('children', 'guardianships') AND REFERENCED_TABLE_NAME IS NOT NULL)
+         OR (REFERENCED_TABLE_SCHEMA = DATABASE() AND REFERENCED_TABLE_NAME IN ('children', 'guardianships'))
+)
++ (
+      SELECT COUNT(*)
+      FROM information_schema.TRIGGERS
+      WHERE TRIGGER_SCHEMA = DATABASE()
+        AND (EVENT_OBJECT_TABLE IN ('children', 'guardianships') OR LOWER(ACTION_STATEMENT) REGEXP @iam_retirement_pattern)
+)
++ (
+      SELECT COUNT(*)
+      FROM information_schema.VIEWS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND (VIEW_DEFINITION IS NULL OR LOWER(VIEW_DEFINITION) REGEXP @iam_retirement_pattern)
+)
++ (
+      SELECT COUNT(*)
+      FROM information_schema.ROUTINES
+      WHERE ROUTINE_SCHEMA = DATABASE()
+        AND (ROUTINE_DEFINITION IS NULL OR LOWER(ROUTINE_DEFINITION) REGEXP @iam_retirement_pattern)
+)
++ (
+      SELECT COUNT(*)
+      FROM information_schema.EVENTS
+      WHERE EVENT_SCHEMA = DATABASE()
+        AND (EVENT_DEFINITION IS NULL OR LOWER(EVENT_DEFINITION) REGEXP @iam_retirement_pattern)
+);
+INSERT INTO iam_identity_retirement_assertion (message)
+SELECT 'identity retirement gate failed'
+WHERE @iam_retirement_dependencies <> 0;
+
+SET @iam_children_rows = (SELECT COUNT(*) FROM children);
+SET @iam_guardianships_rows = (SELECT COUNT(*) FROM guardianships);
+DROP TEMPORARY TABLE iam_identity_retirement_assertion;
+
+-- The owner explicitly waived legacy-to-canonical reconciliation. Keep this
+-- as the only destructive statement and do not write canonical tables.
+DROP TABLE children, guardianships;
+
+DO RELEASE_LOCK('iam_retire_children_guardianships');
+SELECT @iam_children_rows, @iam_guardianships_rows;
+SQL
+
+  echo "identity retirement started: mode=apply action=direct_drop reconciliation=waived_by_owner"
+  if ! result="$("$MYSQL_BIN" --defaults-extra-file="$MYSQL_DEFAULTS" --batch --skip-column-names --raw \
+      "$MYSQL_DBNAME" <"$SQL_PATH" 2>"$ERROR_PATH")"; then
+    fail "identity retirement SQL did not complete; raw database errors were withheld"
+    return 1
+  fi
+  if ! [[ "$result" =~ ^[0-9]+$'\t'[0-9]+$ ]]; then
+    fail "identity retirement completion evidence is invalid"
+    return 1
+  fi
+  local children_rows guardianship_rows
+  IFS=$'\t' read -r children_rows guardianship_rows <<<"$result"
+  echo "identity retirement completed: mode=apply result=success children_rows_deleted=$children_rows guardianships_rows_deleted=$guardianship_rows canonical_writes=0"
+}
+
 main() {
   umask 077
   validate_configuration || return 1
@@ -320,6 +560,7 @@ main() {
     backup) backup_database ;;
     restore) restore_database ;;
     status) database_status ;;
+    retire-identity-dry-run|retire-identity-apply) retire_identity_tables ;;
   esac
 }
 

--- a/scripts/dbops/database-operation.sh
+++ b/scripts/dbops/database-operation.sh
@@ -8,11 +8,14 @@ BACKUP_DIR="${IAM_DB_OPS_BACKUP_DIR:-/opt/backups/iam/database}"
 MYSQL_BIN="${IAM_DB_OPS_MYSQL_BIN:-mysql}"
 MYSQLDUMP_BIN="${IAM_DB_OPS_MYSQLDUMP_BIN:-mysqldump}"
 TIMESTAMP_OVERRIDE="${IAM_DB_OPS_TIMESTAMP:-}"
+ALLOW_DOCKER_CLIENT="${IAM_DB_OPS_ALLOW_DOCKER_CLIENT:-0}"
+MYSQL_CLIENT_IMAGE="${IAM_DB_OPS_MYSQL_CLIENT_IMAGE:-mysql:8.0}"
 
 MYSQL_DEFAULTS=""
 PARTIAL_PATH=""
 ERROR_PATH=""
 MYSQL_CLIENT_VERSION=""
+CLIENT_WRAPPER_DIR=""
 
 fail() {
   echo "database operation failed: $1" >&2
@@ -28,6 +31,63 @@ cleanup() {
   fi
   if [ -n "$ERROR_PATH" ]; then
     rm -f -- "$ERROR_PATH"
+  fi
+  if [ -n "$CLIENT_WRAPPER_DIR" ]; then
+    rm -f -- "$CLIENT_WRAPPER_DIR/mysql" "$CLIENT_WRAPPER_DIR/mysqldump"
+    rmdir -- "$CLIENT_WRAPPER_DIR" 2>/dev/null || true
+  fi
+}
+
+prepare_container_client_fallback() {
+  local docker_bin sudo_bin wrapper client
+  if command -v "$MYSQL_BIN" >/dev/null 2>&1 && command -v "$MYSQLDUMP_BIN" >/dev/null 2>&1; then
+    return
+  fi
+  if [ "$ALLOW_DOCKER_CLIENT" != "1" ]; then
+    return
+  fi
+  if ! [[ "$MYSQL_CLIENT_IMAGE" =~ ^[A-Za-z0-9._/@:-]+$ ]]; then
+    fail "MySQL client image is invalid"
+    return 1
+  fi
+  docker_bin="$(command -v "${IAM_DB_OPS_DOCKER_BIN:-docker}" 2>/dev/null || true)"
+  sudo_bin="$(command -v "${IAM_DB_OPS_SUDO_BIN:-sudo}" 2>/dev/null || true)"
+  if [ -z "$docker_bin" ] || [ -z "$sudo_bin" ] || ! "$sudo_bin" -n "$docker_bin" info >/dev/null 2>&1; then
+    fail "containerized MySQL client is unavailable"
+    return 1
+  fi
+
+  CLIENT_WRAPPER_DIR="$(mktemp -d "${TMPDIR:-/tmp}/iam-mysql-client-wrapper.XXXXXX")"
+  chmod 0700 "$CLIENT_WRAPPER_DIR"
+  export IAM_DB_OPS_DOCKER_BIN="$docker_bin"
+  export IAM_DB_OPS_SUDO_BIN="$sudo_bin"
+  export IAM_DB_OPS_MYSQL_CLIENT_IMAGE="$MYSQL_CLIENT_IMAGE"
+  for client in mysql mysqldump; do
+    wrapper="$CLIENT_WRAPPER_DIR/$client"
+    cat >"$wrapper" <<'EOF'
+#!/bin/sh
+set -eu
+client="$(basename "$0")"
+defaults=""
+for argument in "$@"; do
+  case "$argument" in
+    --defaults-extra-file=*) defaults="${argument#*=}" ;;
+  esac
+done
+if [ -n "$defaults" ]; then
+  exec "$IAM_DB_OPS_SUDO_BIN" -n "$IAM_DB_OPS_DOCKER_BIN" run --rm -i --network host \
+    --volume "$defaults:$defaults:ro" "$IAM_DB_OPS_MYSQL_CLIENT_IMAGE" "$client" "$@"
+fi
+exec "$IAM_DB_OPS_SUDO_BIN" -n "$IAM_DB_OPS_DOCKER_BIN" run --rm -i --network host \
+  "$IAM_DB_OPS_MYSQL_CLIENT_IMAGE" "$client" "$@"
+EOF
+    chmod 0700 "$wrapper"
+  done
+  if ! command -v "$MYSQL_BIN" >/dev/null 2>&1; then
+    MYSQL_BIN="$CLIENT_WRAPPER_DIR/mysql"
+  fi
+  if ! command -v "$MYSQLDUMP_BIN" >/dev/null 2>&1; then
+    MYSQLDUMP_BIN="$CLIENT_WRAPPER_DIR/mysqldump"
   fi
 }
 
@@ -245,6 +305,7 @@ database_status() {
 main() {
   umask 077
   validate_configuration || return 1
+  prepare_container_client_fallback || return 1
   case "$OPERATION" in
     backup) backup_database ;;
     restore) restore_database ;;

--- a/scripts/dbops/database-operation.sh
+++ b/scripts/dbops/database-operation.sh
@@ -69,16 +69,26 @@ prepare_container_client_fallback() {
 set -eu
 client="$(basename "$0")"
 defaults=""
+needs_stdin=0
+has_execute=0
 for argument in "$@"; do
   case "$argument" in
     --defaults-extra-file=*) defaults="${argument#*=}" ;;
+    -e|--execute|--execute=*) has_execute=1 ;;
   esac
 done
+if [ "$client" = "mysql" ] && [ "$has_execute" -eq 0 ] && [ "${1:-}" != "--version" ]; then
+  needs_stdin=1
+fi
 if [ -n "$defaults" ]; then
-  exec "$IAM_DB_OPS_SUDO_BIN" -n "$IAM_DB_OPS_DOCKER_BIN" run --rm -i --network host \
+  if [ "$needs_stdin" -eq 1 ]; then
+    exec "$IAM_DB_OPS_SUDO_BIN" -n "$IAM_DB_OPS_DOCKER_BIN" run --rm -i --network host \
+      --volume "$defaults:$defaults:ro" "$IAM_DB_OPS_MYSQL_CLIENT_IMAGE" "$client" "$@"
+  fi
+  exec "$IAM_DB_OPS_SUDO_BIN" -n "$IAM_DB_OPS_DOCKER_BIN" run --rm --network host \
     --volume "$defaults:$defaults:ro" "$IAM_DB_OPS_MYSQL_CLIENT_IMAGE" "$client" "$@"
 fi
-exec "$IAM_DB_OPS_SUDO_BIN" -n "$IAM_DB_OPS_DOCKER_BIN" run --rm -i --network host \
+exec "$IAM_DB_OPS_SUDO_BIN" -n "$IAM_DB_OPS_DOCKER_BIN" run --rm --network host \
   "$IAM_DB_OPS_MYSQL_CLIENT_IMAGE" "$client" "$@"
 EOF
     chmod 0700 "$wrapper"

--- a/scripts/dbops/database_operation_test.go
+++ b/scripts/dbops/database_operation_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 const secretSentinel = "db-ops-password-sentinel"
@@ -266,6 +267,115 @@ esac
 	}
 }
 
+func TestIdentityRetirementRequiresFreshBackupConfirmationAndDropsOnlyLegacyTables(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	backupDir := filepath.Join(root, "backups")
+	capture := filepath.Join(root, "identity-retirement.sql")
+	requireNoError(t, os.MkdirAll(bin, 0o700))
+	requireNoError(t, os.MkdirAll(backupDir, 0o700))
+	writeExecutable(t, bin, "mysql", `#!/bin/sh
+if [ "$1" = "--version" ]; then echo 'mysql  Ver 8.0.36'; exit 0; fi
+case "$*" in
+  *"MAX(version)"*) printf '18\t0\t1\n' ;;
+  *"TABLE_NAME = 'children'"*"TABLE_TYPE = 'BASE TABLE'"*) printf '1\t1\n' ;;
+  *"COUNT(*) FROM children"*) printf '64\t66\n' ;;
+  *"KEY_COLUMN_USAGE"*) printf '%s\n' "${IAM_FAKE_DEPENDENCY_COUNT:-0}" ;;
+  *) cat > "$IAM_FAKE_IDENTITY_RETIREMENT_CAPTURE"; printf '64\t66\n' ;;
+esac
+`)
+	backupName := "iam_backup_20260807_170129.sql.gz"
+	writeGzip(t, filepath.Join(backupDir, backupName), "verified backup fixture")
+
+	base := map[string]string{
+		"IAM_DB_OPS_OPERATION":                 "retire-identity-dry-run",
+		"IAM_DB_OPS_BACKUP_DIR":                backupDir,
+		"IAM_DB_OPS_BACKUP_NAME":               backupName,
+		"IAM_FAKE_IDENTITY_RETIREMENT_CAPTURE": capture,
+		"IAM_DB_OPS_MAX_BACKUP_AGE_SECONDS":    "7200",
+	}
+	output, err := runScript(t, bin, base)
+	requireNoError(t, err)
+	assertSafeOutput(t, output)
+	for _, want := range []string{
+		"state=eligible", "migration_version=18", "dependencies=0",
+		"children_rows=64", "guardianships_rows=66", "reconciliation=waived_by_owner",
+		"mode=dry-run result=success",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("identity dry-run output missing %q: %s", want, output)
+		}
+	}
+
+	base["IAM_FAKE_DEPENDENCY_COUNT"] = "1"
+	output, err = runScript(t, bin, base)
+	if err == nil || !strings.Contains(output, "database dependencies still exist") {
+		t.Fatalf("identity dry-run with dependency: err=%v output=%s", err, output)
+	}
+	assertSafeOutput(t, output)
+	delete(base, "IAM_FAKE_DEPENDENCY_COUNT")
+
+	base["IAM_DB_OPS_OPERATION"] = "retire-identity-apply"
+	output, err = runScript(t, bin, base)
+	if err == nil || !strings.Contains(output, "confirmation is invalid") {
+		t.Fatalf("identity apply without confirmation: err=%v output=%s", err, output)
+	}
+	assertSafeOutput(t, output)
+
+	base["IAM_DB_OPS_CONFIRMATION"] = "RETIRE_CHILDREN_GUARDIANSHIPS"
+	output, err = runScript(t, bin, base)
+	requireNoError(t, err)
+	assertSafeOutput(t, output)
+	for _, want := range []string{
+		"mode=apply result=success", "children_rows_deleted=64",
+		"guardianships_rows_deleted=66", "canonical_writes=0",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("identity apply output missing %q: %s", want, output)
+		}
+	}
+
+	sql, err := os.ReadFile(capture)
+	requireNoError(t, err)
+	source := string(sql)
+	if strings.Count(source, "DROP TABLE children, guardianships;") != 1 {
+		t.Fatalf("identity retirement must contain one exact final legacy DROP: %s", source)
+	}
+	for _, forbidden := range []string{
+		"INSERT INTO profiles", "UPDATE profiles", "DELETE FROM profiles",
+		"INSERT INTO profile_links", "UPDATE profile_links", "DELETE FROM profile_links",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("identity retirement contains forbidden canonical write %q", forbidden)
+		}
+	}
+}
+
+func TestIdentityRetirementRejectsStaleBackup(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	backupDir := filepath.Join(root, "backups")
+	requireNoError(t, os.MkdirAll(bin, 0o700))
+	requireNoError(t, os.MkdirAll(backupDir, 0o700))
+	writeExecutable(t, bin, "mysql", "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'mysql  Ver 8.0.36'; exit 0; fi\nexit 99\n")
+	backupName := "iam_backup_20260807_170129.sql.gz"
+	backupPath := filepath.Join(backupDir, backupName)
+	writeGzip(t, backupPath, "stale backup fixture")
+	stale := time.Now().Add(-3 * time.Hour)
+	requireNoError(t, os.Chtimes(backupPath, stale, stale))
+
+	output, err := runScript(t, bin, map[string]string{
+		"IAM_DB_OPS_OPERATION":              "retire-identity-dry-run",
+		"IAM_DB_OPS_BACKUP_DIR":             backupDir,
+		"IAM_DB_OPS_BACKUP_NAME":            backupName,
+		"IAM_DB_OPS_MAX_BACKUP_AGE_SECONDS": "7200",
+	})
+	if err == nil || !strings.Contains(output, "retirement backup is stale") {
+		t.Fatalf("stale retirement backup: err=%v output=%s", err, output)
+	}
+	assertSafeOutput(t, output)
+}
+
 func TestStatusFallsBackToOfficialMySQLContainerClient(t *testing.T) {
 	root := t.TempDir()
 	bin := filepath.Join(root, "bin")
@@ -327,10 +437,10 @@ func TestWorkflowUsesSingleCheckedOutScriptAndMySQLIntegration(t *testing.T) {
 	workflow, err := os.ReadFile(filepath.Join(repo, ".github", "workflows", "db-ops.yml"))
 	requireNoError(t, err)
 	source := string(workflow)
-	if strings.Count(source, "uses: actions/checkout@v6") != 3 {
+	if strings.Count(source, "uses: actions/checkout@v6") != 4 {
 		t.Fatal("every database operation job must checkout the repository script")
 	}
-	if strings.Count(source, "script_path: scripts/dbops/database-operation.sh") != 3 {
+	if strings.Count(source, "script_path: scripts/dbops/database-operation.sh") != 4 {
 		t.Fatal("every database operation job must use the single script_path")
 	}
 	if strings.Count(source, "script_path: scripts/dbops/legacy-retirement-preflight.sh") != 1 {
@@ -340,6 +450,8 @@ func TestWorkflowUsesSingleCheckedOutScriptAndMySQLIntegration(t *testing.T) {
 		"image_sha:", "IAM_RETIREMENT_IMAGE_SHA", "Run Legacy Retirement Preflight",
 		"IAM_DB_OPS_ALLOW_DOCKER_CLIENT", "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
 		"retirement_scope:", "IAM_RETIREMENT_SCOPE",
+		"retire-identity-dry-run", "retire-identity-apply",
+		"IAM_DB_OPS_CONFIRMATION", "confirmation:",
 	} {
 		if !strings.Contains(source, want) {
 			t.Fatalf("database status preflight is missing %q", want)
@@ -353,7 +465,12 @@ func TestWorkflowUsesSingleCheckedOutScriptAndMySQLIntegration(t *testing.T) {
 
 	concurrency, err := os.ReadFile(filepath.Join(repo, ".github", "workflows", "concurrency-tests.yml"))
 	requireNoError(t, err)
-	for _, want := range []string{"Verify database backup and restore script with MySQL 8", "IAM_DB_OPS_OPERATION=backup", "IAM_DB_OPS_OPERATION=restore"} {
+	for _, want := range []string{
+		"Verify database backup, restore, and Identity retirement with MySQL 8",
+		"IAM_DB_OPS_OPERATION=backup", "IAM_DB_OPS_OPERATION=restore",
+		"IAM_DB_OPS_OPERATION=retire-identity-dry-run",
+		"IAM_DB_OPS_OPERATION=retire-identity-apply",
+	} {
 		if !strings.Contains(string(concurrency), want) {
 			t.Fatalf("MySQL workflow is missing %q", want)
 		}

--- a/scripts/dbops/database_operation_test.go
+++ b/scripts/dbops/database_operation_test.go
@@ -339,6 +339,7 @@ func TestWorkflowUsesSingleCheckedOutScriptAndMySQLIntegration(t *testing.T) {
 	for _, want := range []string{
 		"image_sha:", "IAM_RETIREMENT_IMAGE_SHA", "Run Legacy Retirement Preflight",
 		"IAM_DB_OPS_ALLOW_DOCKER_CLIENT", "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
+		"retirement_scope:", "IAM_RETIREMENT_SCOPE",
 	} {
 		if !strings.Contains(source, want) {
 			t.Fatalf("database status preflight is missing %q", want)

--- a/scripts/dbops/database_operation_test.go
+++ b/scripts/dbops/database_operation_test.go
@@ -266,6 +266,61 @@ esac
 	}
 }
 
+func TestStatusFallsBackToOfficialMySQLContainerClient(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	backupDir := filepath.Join(root, "backups")
+	requireNoError(t, os.MkdirAll(bin, 0o700))
+	requireNoError(t, os.MkdirAll(backupDir, 0o700))
+	writeExecutable(t, bin, "sudo", `#!/bin/sh
+if [ "$1" = "-n" ]; then shift; fi
+exec "$@"
+`)
+	writeExecutable(t, bin, "docker", `#!/bin/sh
+set -eu
+if [ "$1" = "info" ]; then exit 0; fi
+[ "$1" = "run" ]
+shift
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --rm|-i) shift ;;
+    --network|--volume) shift 2 ;;
+    *) shift; break ;;
+  esac
+done
+client="$1"
+shift
+if [ "${1:-}" = "--version" ]; then
+  printf '%s  Ver 8.0.36\n' "$client"
+  exit 0
+fi
+case "$*" in
+  *"SUM(data_length"*) printf '12.5\n' ;;
+  *"COUNT(*)"*) printf '7\n' ;;
+  *) printf '1\n' ;;
+esac
+`)
+
+	output, err := runScriptWithBaseEnv(t, []string{
+		"PATH=" + bin + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}, map[string]string{
+		"IAM_DB_OPS_OPERATION":           "status",
+		"IAM_DB_OPS_BACKUP_DIR":          backupDir,
+		"IAM_DB_OPS_MYSQL_BIN":           "iam-mysql-missing",
+		"IAM_DB_OPS_MYSQLDUMP_BIN":       "iam-mysqldump-missing",
+		"IAM_DB_OPS_ALLOW_DOCKER_CLIENT": "1",
+		"IAM_DB_OPS_DOCKER_BIN":          filepath.Join(bin, "docker"),
+		"IAM_DB_OPS_SUDO_BIN":            filepath.Join(bin, "sudo"),
+	})
+	requireNoError(t, err)
+	assertSafeOutput(t, output)
+	for _, want := range []string{"mysql_client=8.0.36", "connection=success", "size_mb=12.5", "tables=7"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("container fallback output missing %q: %s", want, output)
+		}
+	}
+}
+
 func TestWorkflowUsesSingleCheckedOutScriptAndMySQLIntegration(t *testing.T) {
 	_, file, _, _ := runtime.Caller(0)
 	repo := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
@@ -281,7 +336,10 @@ func TestWorkflowUsesSingleCheckedOutScriptAndMySQLIntegration(t *testing.T) {
 	if strings.Count(source, "script_path: scripts/dbops/legacy-retirement-preflight.sh") != 1 {
 		t.Fatal("database status must run the checked-out legacy retirement preflight once")
 	}
-	for _, want := range []string{"image_sha:", "IAM_RETIREMENT_IMAGE_SHA", "Run Legacy Retirement Preflight"} {
+	for _, want := range []string{
+		"image_sha:", "IAM_RETIREMENT_IMAGE_SHA", "Run Legacy Retirement Preflight",
+		"IAM_DB_OPS_ALLOW_DOCKER_CLIENT", "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
+	} {
 		if !strings.Contains(source, want) {
 			t.Fatalf("database status preflight is missing %q", want)
 		}

--- a/scripts/dbops/database_operation_test.go
+++ b/scripts/dbops/database_operation_test.go
@@ -278,6 +278,14 @@ func TestWorkflowUsesSingleCheckedOutScriptAndMySQLIntegration(t *testing.T) {
 	if strings.Count(source, "script_path: scripts/dbops/database-operation.sh") != 3 {
 		t.Fatal("every database operation job must use the single script_path")
 	}
+	if strings.Count(source, "script_path: scripts/dbops/legacy-retirement-preflight.sh") != 1 {
+		t.Fatal("database status must run the checked-out legacy retirement preflight once")
+	}
+	for _, want := range []string{"image_sha:", "IAM_RETIREMENT_IMAGE_SHA", "Run Legacy Retirement Preflight"} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("database status preflight is missing %q", want)
+		}
+	}
 	for _, forbidden := range []string{"apt-get", "apk add", "script: |", "SHOW TABLES", "Largest tables"} {
 		if strings.Contains(source, forbidden) {
 			t.Fatalf("database workflow contains forbidden inline/runtime behavior %q", forbidden)

--- a/scripts/dbops/legacy-retirement-preflight.sh
+++ b/scripts/dbops/legacy-retirement-preflight.sh
@@ -10,7 +10,15 @@ SUPPLIED_DEFAULTS="${IAM_RETIREMENT_MYSQL_DEFAULTS_FILE:-}"
 
 MYSQL_DEFAULTS=""
 ERROR_PATH=""
+IO_CACHE_PATH=""
+DEPENDENCY_CACHE_PATH=""
+PARITY_CACHE_PATH=""
 OWNS_DEFAULTS=0
+
+MIGRATION_PRESENT=0
+MIGRATION_VERSION=unknown
+MIGRATION_DIRTY=unknown
+PERFORMANCE_ENABLED=0
 
 CANDIDATE_TABLES="children guardianships auth_accounts auth_credentials_legacy schema_version tenants data_dictionary operation_logs audit_logs auth_token_audit"
 
@@ -25,6 +33,15 @@ cleanup() {
   fi
   if [ -n "$ERROR_PATH" ]; then
     rm -f -- "$ERROR_PATH"
+  fi
+  if [ -n "$IO_CACHE_PATH" ]; then
+    rm -f -- "$IO_CACHE_PATH"
+  fi
+  if [ -n "$DEPENDENCY_CACHE_PATH" ]; then
+    rm -f -- "$DEPENDENCY_CACHE_PATH"
+  fi
+  if [ -n "$PARITY_CACHE_PATH" ]; then
+    rm -f -- "$PARITY_CACHE_PATH"
   fi
 }
 
@@ -151,12 +168,15 @@ emit_metadata() {
 emit_migration_state() {
   local present state version dirty rows
   present="$(table_present schema_migrations)"
+  MIGRATION_PRESENT="$present"
   if [ "$present" != "1" ]; then
     printf 'migration\tschema_migrations\tabsent\tversion=unknown\tdirty=unknown\n'
     return
   fi
   state="$(mysql_query "SELECT COALESCE(MAX(version), 0), COALESCE(MAX(dirty + 0), 0), COUNT(*) FROM schema_migrations;")"
   IFS=$'\t' read -r version dirty rows <<<"$state"
+  MIGRATION_VERSION="$version"
+  MIGRATION_DIRTY="$dirty"
   printf 'migration\tschema_migrations\tpresent\tversion=%s\tdirty=%s\trows=%s\n' "$version" "$dirty" "$rows"
 }
 
@@ -170,9 +190,48 @@ emit_candidate_tables() {
   done
 }
 
+emit_exact_row_counts() {
+  local table present exact_rows
+  for table in $CANDIDATE_TABLES; do
+    present="$(table_present "$table")"
+    if [ "$present" != "1" ]; then
+      printf 'exact_rows\t%s\tstate=absent\n' "$table"
+      continue
+    fi
+    exact_rows="$(mysql_query "SELECT COUNT(*) FROM $table;")"
+    printf 'exact_rows\t%s\tstate=available\trows=%s\n' "$table" "$exact_rows"
+  done
+}
+
+emit_schema_signatures() {
+  local table present columns indexes column_sha index_sha signature
+  for table in $CANDIDATE_TABLES; do
+    present="$(table_present "$table")"
+    if [ "$present" != "1" ]; then
+      printf 'schema_signature\t%s\tstate=absent\n' "$table"
+      continue
+    fi
+    signature="$(mysql_query "SELECT
+      COUNT(*),
+      COALESCE(SHA2(GROUP_CONCAT(CONCAT_WS(':', ORDINAL_POSITION, COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COALESCE(COLUMN_DEFAULT, '<NULL>'), EXTRA) ORDER BY ORDINAL_POSITION SEPARATOR '|'), 256), 'unavailable')
+      FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '$table';")"
+    IFS=$'\t' read -r columns column_sha <<<"$signature"
+    signature="$(mysql_query "SELECT
+      COUNT(*),
+      COALESCE(SHA2(GROUP_CONCAT(CONCAT_WS(':', INDEX_NAME, SEQ_IN_INDEX, COLUMN_NAME, NON_UNIQUE, COALESCE(SUB_PART, 0)) ORDER BY INDEX_NAME, SEQ_IN_INDEX SEPARATOR '|'), 256), 'unavailable')
+      FROM information_schema.STATISTICS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '$table';")"
+    IFS=$'\t' read -r indexes index_sha <<<"$signature"
+    printf 'schema_signature\t%s\tstate=available\tcolumns=%s\tindexes=%s\tcolumn_sha256=%s\tindex_sha256=%s\n' \
+      "$table" "$columns" "$indexes" "$column_sha" "$index_sha"
+  done
+}
+
 emit_performance_schema_io() {
   local enabled uptime table io count_star timer_wait reads writes
   enabled="$(mysql_query "SELECT @@performance_schema + 0;")"
+  PERFORMANCE_ENABLED="$enabled"
   if [ "$enabled" != "1" ]; then
     printf 'performance_schema\tstate=disabled\tcounter_scope=unavailable\n'
     return
@@ -188,8 +247,10 @@ emit_performance_schema_io() {
   for table in $CANDIDATE_TABLES; do
     if io="$(mysql_query_optional "SELECT COALESCE(SUM(COUNT_STAR), 0), COALESCE(SUM(SUM_TIMER_WAIT), 0), COALESCE(SUM(COUNT_READ), 0), COALESCE(SUM(COUNT_WRITE), 0) FROM performance_schema.table_io_waits_summary_by_table WHERE OBJECT_SCHEMA = DATABASE() AND OBJECT_NAME = '$table';")" && [ -n "$io" ]; then
       IFS=$'\t' read -r count_star timer_wait reads writes <<<"$io"
+      printf '%s\tavailable\t%s\t%s\n' "$table" "$reads" "$writes" >>"$IO_CACHE_PATH"
       printf 'table_io\t%s\tcount_star=%s\ttimer_wait=%s\treads=%s\twrites=%s\n' "$table" "$count_star" "$timer_wait" "$reads" "$writes"
     else
+      printf '%s\tunavailable\tunknown\tunknown\n' "$table" >>"$IO_CACHE_PATH"
       printf 'table_io\t%s\tstate=unavailable\n' "$table"
     fi
   done
@@ -208,6 +269,9 @@ emit_dependencies() {
       (SELECT COUNT(*) FROM information_schema.EVENTS WHERE EVENT_SCHEMA = DATABASE() AND EVENT_DEFINITION IS NOT NULL AND INSTR(LOWER(EVENT_DEFINITION), '$table') > 0),
       (SELECT COUNT(*) FROM information_schema.EVENTS WHERE EVENT_SCHEMA = DATABASE() AND EVENT_DEFINITION IS NULL);")"
     IFS=$'\t' read -r fk triggers view_refs opaque_views routine_refs opaque_routines event_refs opaque_events <<<"$dependencies"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$table" "$fk" "$triggers" "$view_refs" "$opaque_views" "$routine_refs" "$opaque_routines" "$event_refs" "$opaque_events" \
+      >>"$DEPENDENCY_CACHE_PATH"
     printf 'dependency\t%s\tfk=%s\ttriggers=%s\tviews=%s\topaque_views=%s\troutines=%s\topaque_routines=%s\tevents=%s\topaque_events=%s\n' \
       "$table" "$fk" "$triggers" "$view_refs" "$opaque_views" "$routine_refs" "$opaque_routines" "$event_refs" "$opaque_events"
   done
@@ -221,13 +285,16 @@ emit_parity_result() {
   for table in $required_tables; do
     present="$(table_present "$table")"
     if [ "$present" != "1" ]; then
+      printf '%s\tnot_applicable\tmissing_table=%s\n' "$name" "$table" >>"$PARITY_CACHE_PATH"
       printf 'parity\t%s\tstate=not_applicable\tmissing_table=%s\n' "$name" "$table"
       return
     fi
   done
   if result="$(mysql_query_optional "$sql")" && [ -n "$result" ]; then
+    printf '%s\tavailable\t%s\n' "$name" "$result" >>"$PARITY_CACHE_PATH"
     printf 'parity\t%s\tstate=available\t%s\n' "$name" "$result"
   else
+    printf '%s\tunavailable\treason=schema_or_privilege_mismatch\n' "$name" >>"$PARITY_CACHE_PATH"
     printf 'parity\t%s\tstate=unavailable\treason=schema_or_privilege_mismatch\n' "$name"
   fi
 }
@@ -254,51 +321,306 @@ emit_parity_summaries() {
       p.revoked_at <=> g.revoked_at AND p.deleted_at <=> g.deleted_at AND p.version <=> g.version)), 0))
     FROM guardianships g LEFT JOIN profile_links p ON p.id = g.id;"
 
-  emit_parity_result auth_accounts_to_login_identities "auth_accounts auth_login_identities" "SELECT
-    CONCAT('legacy_rows=', COUNT(*)),
-    CONCAT('supported_rows=', COALESCE(SUM(a.type IN ('opera', 'mock-consumer', 'wc-minip', 'wc-com')), 0)),
-    CONCAT('mapped_rows=', COALESCE(SUM(a.type IN ('opera', 'mock-consumer', 'wc-minip', 'wc-com') AND EXISTS (
-      SELECT 1 FROM auth_login_identities li
-      WHERE JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_account_id')) = CAST(a.id AS CHAR))), 0)),
-    CONCAT('missing_supported_rows=', COALESCE(SUM(a.type IN ('opera', 'mock-consumer', 'wc-minip', 'wc-com') AND NOT EXISTS (
-      SELECT 1 FROM auth_login_identities li
-      WHERE JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_account_id')) = CAST(a.id AS CHAR))), 0)),
-    CONCAT('mismatched_mapped_rows=', COALESCE(SUM(a.type IN ('opera', 'mock-consumer', 'wc-minip', 'wc-com') AND EXISTS (
-      SELECT 1 FROM auth_login_identities li
-      WHERE JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_account_id')) = CAST(a.id AS CHAR))
-      AND NOT EXISTS (
+  emit_parity_result auth_accounts_to_login_identities "auth_accounts auth_login_identities" "WITH account_facts AS (
+    SELECT a.*,
+      a.type IN ('opera', 'mock-consumer', 'wc-minip', 'wc-com') AS supported,
+      (TRIM(a.external_id) <> '' AND (a.type NOT IN ('wc-minip', 'wc-com') OR TRIM(COALESCE(a.app_id, '')) <> '')) AS valid_key,
+      (SELECT COUNT(*) FROM auth_login_identities li
+       WHERE CAST(JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_account_id')) AS UNSIGNED) = a.id
+         AND CAST(JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_table')) AS BINARY) = CAST('auth_accounts' AS BINARY)) AS mapping_count,
+      EXISTS (
         SELECT 1 FROM auth_login_identities li
-        WHERE JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_account_id')) = CAST(a.id AS CHAR)
+        WHERE CAST(JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_account_id')) AS UNSIGNED) = a.id
+          AND CAST(JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_table')) AS BINARY) = CAST('auth_accounts' AS BINARY)
           AND li.user_id = a.user_id
-          AND li.provider = CASE a.type WHEN 'wc-minip' THEN 'wechat_minip' WHEN 'wc-com' THEN 'wecom' ELSE 'username' END
-          AND li.realm = CASE WHEN a.type = 'opera' AND a.scoped_tenant_id <> 0 THEN CAST(a.scoped_tenant_id AS CHAR)
-                              WHEN a.type IN ('wc-minip', 'wc-com') THEN TRIM(a.app_id) ELSE 'default' END
-          AND li.identifier = TRIM(a.external_id)
-          AND li.status = CASE a.status WHEN 1 THEN 'active' WHEN 2 THEN 'archived' WHEN 3 THEN 'deleted' ELSE 'disabled' END)), 0))
-    FROM auth_accounts a;"
-
-  emit_parity_result legacy_credentials_to_authn "auth_credentials_legacy auth_credentials auth_login_identities" "SELECT
+          AND CAST(li.provider AS BINARY) = CAST(CASE a.type WHEN 'wc-minip' THEN 'wechat_minip' WHEN 'wc-com' THEN 'wecom' ELSE 'username' END AS BINARY)
+          AND CAST(li.realm AS BINARY) = CAST(CASE WHEN a.type = 'opera' AND a.scoped_tenant_id <> 0 THEN CAST(a.scoped_tenant_id AS CHAR)
+                              WHEN a.type IN ('wc-minip', 'wc-com') THEN TRIM(a.app_id) ELSE 'default' END AS BINARY)
+          AND CAST(li.identifier AS BINARY) = CAST(TRIM(a.external_id) AS BINARY)
+          AND CAST(li.global_identifier AS BINARY) <=> CAST(NULLIF(TRIM(COALESCE(a.unique_id, '')), '') AS BINARY)
+          AND CAST(li.status AS BINARY) = CAST(CASE a.status WHEN 1 THEN 'active' WHEN 2 THEN 'archived' WHEN 3 THEN 'deleted' ELSE 'disabled' END AS BINARY)
+      ) AS exact_mapping
+    FROM auth_accounts a
+  )
+  SELECT
     CONCAT('legacy_rows=', COUNT(*)),
-    CONCAT('password_eligible_rows=', COALESCE(SUM((lc.type = 'password' OR COALESCE(lc.idp, '') = '') AND OCTET_LENGTH(lc.material) > 0 AND COALESCE(lc.algo, '') <> ''), 0)),
-    CONCAT('password_mapped_rows=', COALESCE(SUM(
-      (lc.type = 'password' OR COALESCE(lc.idp, '') = '') AND OCTET_LENGTH(lc.material) > 0 AND COALESCE(lc.algo, '') <> ''
-      AND EXISTS (SELECT 1 FROM auth_credentials c
-                  WHERE JSON_UNQUOTE(JSON_EXTRACT(c.params_json, '$.legacy_credential_id')) = CAST(lc.id AS CHAR))), 0)),
-    CONCAT('password_material_mismatches=', COALESCE(SUM(
-      (lc.type = 'password' OR COALESCE(lc.idp, '') = '') AND OCTET_LENGTH(lc.material) > 0 AND COALESCE(lc.algo, '') <> ''
-      AND EXISTS (SELECT 1 FROM auth_credentials c
-                  WHERE JSON_UNQUOTE(JSON_EXTRACT(c.params_json, '$.legacy_credential_id')) = CAST(lc.id AS CHAR))
-      AND NOT EXISTS (SELECT 1 FROM auth_credentials c
-                      WHERE JSON_UNQUOTE(JSON_EXTRACT(c.params_json, '$.legacy_credential_id')) = CAST(lc.id AS CHAR)
-                        AND SHA2(c.material, 256) <=> SHA2(lc.material, 256)
-                        AND c.algo <=> lc.algo
-                        AND c.status = IF(lc.status = 1, 'enabled', 'disabled'))), 0)),
-    CONCAT('phone_eligible_rows=', COALESCE(SUM(lc.type = 'phone_otp' OR COALESCE(lc.idp, '') = 'phone'), 0)),
-    CONCAT('phone_identity_mapped_rows=', COALESCE(SUM(
-      (lc.type = 'phone_otp' OR COALESCE(lc.idp, '') = 'phone')
-      AND EXISTS (SELECT 1 FROM auth_login_identities li
-                  WHERE JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_credential_id')) = CAST(lc.id AS CHAR))), 0))
-    FROM auth_credentials_legacy lc;"
+    CONCAT('supported_rows=', COALESCE(SUM(supported), 0)),
+    CONCAT('valid_supported_rows=', COALESCE(SUM(supported AND valid_key), 0)),
+    CONCAT('invalid_supported_rows=', COALESCE(SUM(supported AND NOT valid_key), 0)),
+    CONCAT('unsupported_rows=', COALESCE(SUM(NOT supported), 0)),
+    CONCAT('mapped_rows=', COALESCE(SUM(supported AND valid_key AND mapping_count > 0), 0)),
+    CONCAT('missing_supported_rows=', COALESCE(SUM(supported AND valid_key AND mapping_count = 0), 0)),
+    CONCAT('mismatched_mapped_rows=', COALESCE(SUM(supported AND valid_key AND mapping_count > 0 AND NOT exact_mapping), 0)),
+    CONCAT('duplicate_mapped_rows=', COALESCE(SUM(supported AND valid_key AND mapping_count > 1), 0))
+  FROM account_facts;"
+
+  emit_parity_result legacy_credentials_to_authn "auth_credentials_legacy auth_credentials auth_login_identities auth_accounts" "WITH credential_facts AS (
+    SELECT lc.*,
+      ((lc.type = 'password' OR COALESCE(lc.idp, '') = '')
+        AND COALESCE(OCTET_LENGTH(lc.material), 0) > 0 AND COALESCE(lc.algo, '') <> '') AS password_eligible,
+      (lc.type = 'password'
+        AND (COALESCE(OCTET_LENGTH(lc.material), 0) = 0 OR COALESCE(lc.algo, '') = '')) AS invalid_password,
+      (lc.type = 'phone_otp' OR COALESCE(lc.idp, '') = 'phone') AS phone_artifact,
+      (lc.type IN ('oauth_wx_minip', 'oauth_wx_open', 'oauth_wx_scan', 'oauth_wecom')) AS oauth_artifact,
+      (SELECT COUNT(*) FROM auth_credentials c
+       WHERE CAST(JSON_UNQUOTE(JSON_EXTRACT(c.params_json, '$.legacy_credential_id')) AS UNSIGNED) = lc.id) AS password_mapping_count,
+      EXISTS (
+        SELECT 1 FROM auth_credentials c
+        JOIN auth_login_identities li ON li.id = c.login_identity_id
+        WHERE CAST(JSON_UNQUOTE(JSON_EXTRACT(c.params_json, '$.legacy_credential_id')) AS UNSIGNED) = lc.id
+          AND CAST(JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_account_id')) AS UNSIGNED) = lc.account_id
+          AND SHA2(c.material, 256) <=> SHA2(lc.material, 256)
+          AND c.algo <=> lc.algo
+          AND c.status = IF(lc.status = 1, 'enabled', 'disabled')
+          AND c.failed_attempts <=> lc.failed_attempts
+          AND c.locked_until <=> lc.locked_until
+          AND c.last_success_at <=> lc.last_success_at
+          AND c.last_failure_at <=> lc.last_failure_at
+      ) AS exact_password_mapping,
+      (SELECT COUNT(*) FROM auth_login_identities li
+       WHERE CAST(JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_credential_id')) AS UNSIGNED) = lc.id) AS phone_mapping_count,
+      EXISTS (
+        SELECT 1 FROM auth_login_identities li
+        JOIN auth_accounts a ON a.id = lc.account_id
+        WHERE CAST(JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_credential_id')) AS UNSIGNED) = lc.id
+          AND li.user_id = a.user_id
+          AND li.provider = 'phone'
+          AND li.realm = 'global'
+          AND li.identifier = TRIM(lc.idp_identifier)
+          AND li.status = CASE
+            WHEN a.status = 1 AND lc.status <> 1 THEN 'disabled'
+            WHEN a.status = 1 THEN 'active'
+            WHEN a.status = 2 THEN 'archived'
+            WHEN a.status = 3 THEN 'deleted'
+            ELSE 'disabled'
+          END
+      ) AS exact_phone_mapping,
+      EXISTS (SELECT 1 FROM auth_accounts a WHERE a.id = lc.account_id) AS account_exists,
+      EXISTS (
+        SELECT 1 FROM auth_login_identities li
+        WHERE CAST(JSON_UNQUOTE(JSON_EXTRACT(li.meta_json, '$.legacy_account_id')) AS UNSIGNED) = lc.account_id
+          AND li.provider = CASE lc.type
+            WHEN 'oauth_wx_minip' THEN 'wechat_minip'
+            WHEN 'oauth_wecom' THEN 'wecom'
+            ELSE 'wechat_open'
+          END
+      ) AS oauth_identity_exists
+    FROM auth_credentials_legacy lc
+  )
+  SELECT
+    CONCAT('legacy_rows=', COUNT(*)),
+    CONCAT('password_eligible_rows=', COALESCE(SUM(password_eligible), 0)),
+    CONCAT('password_mapped_rows=', COALESCE(SUM(password_eligible AND password_mapping_count > 0), 0)),
+    CONCAT('password_unmapped_rows=', COALESCE(SUM(password_eligible AND password_mapping_count = 0), 0)),
+    CONCAT('password_material_mismatches=', COALESCE(SUM(password_eligible AND password_mapping_count > 0 AND NOT exact_password_mapping), 0)),
+    CONCAT('password_duplicate_mappings=', COALESCE(SUM(password_eligible AND password_mapping_count > 1), 0)),
+    CONCAT('invalid_password_rows=', COALESCE(SUM(invalid_password), 0)),
+    CONCAT('phone_eligible_rows=', COALESCE(SUM(phone_artifact AND TRIM(COALESCE(idp_identifier, '')) <> '' AND account_exists), 0)),
+    CONCAT('phone_identity_mapped_rows=', COALESCE(SUM(phone_artifact AND TRIM(COALESCE(idp_identifier, '')) <> '' AND account_exists AND phone_mapping_count > 0), 0)),
+    CONCAT('phone_blank_identifier_rows=', COALESCE(SUM(phone_artifact AND TRIM(COALESCE(idp_identifier, '')) = ''), 0)),
+    CONCAT('phone_orphan_account_rows=', COALESCE(SUM(phone_artifact AND NOT account_exists), 0)),
+    CONCAT('phone_identity_mismatches=', COALESCE(SUM(phone_artifact AND phone_mapping_count > 0 AND NOT exact_phone_mapping), 0)),
+    CONCAT('phone_duplicate_mappings=', COALESCE(SUM(phone_artifact AND phone_mapping_count > 1), 0)),
+    CONCAT('oauth_artifact_rows=', COALESCE(SUM(oauth_artifact), 0)),
+    CONCAT('oauth_redundant_rows=', COALESCE(SUM(oauth_artifact AND oauth_identity_exists), 0)),
+    CONCAT('oauth_unmapped_rows=', COALESCE(SUM(oauth_artifact AND NOT oauth_identity_exists), 0)),
+    CONCAT('unknown_credential_rows=', COALESCE(SUM(NOT password_eligible AND NOT invalid_password AND NOT phone_artifact AND NOT oauth_artifact), 0))
+  FROM credential_facts;"
+}
+
+cached_parity_state() {
+  local name="$1"
+  awk -F '\t' -v wanted="$name" '$1 == wanted { print $2; exit }' "$PARITY_CACHE_PATH"
+}
+
+cached_parity_value() {
+  local name="$1"
+  local key="$2"
+  awk -F '\t' -v wanted="$name" -v key="$key" '
+    $1 == wanted {
+      for (i = 3; i <= NF; i++) {
+        split($i, pair, "=")
+        if (pair[1] == key) {
+          print pair[2]
+          exit
+        }
+      }
+    }
+  ' "$PARITY_CACHE_PATH"
+}
+
+common_retirement_blocker() {
+  local table="$1"
+  local io_line io_state reads writes dependency_line dependency_total value
+  if [ "$MIGRATION_PRESENT" != "1" ]; then
+    printf 'schema_migrations_absent'
+    return
+  fi
+  if [ "$MIGRATION_DIRTY" != "0" ]; then
+    printf 'schema_migrations_dirty'
+    return
+  fi
+  if ! [[ "$MIGRATION_VERSION" =~ ^[0-9]+$ ]] || [ "$MIGRATION_VERSION" -lt 19 ]; then
+    printf 'migration_version_before_19'
+    return
+  fi
+  if [ "$PERFORMANCE_ENABLED" != "1" ]; then
+    printf 'performance_schema_unavailable'
+    return
+  fi
+  io_line="$(awk -F '\t' -v wanted="$table" '$1 == wanted { print; exit }' "$IO_CACHE_PATH")"
+  if [ -z "$io_line" ]; then
+    printf 'table_io_unavailable'
+    return
+  fi
+  IFS=$'\t' read -r _ io_state reads writes <<<"$io_line"
+  if [ "$io_state" != "available" ]; then
+    printf 'table_io_unavailable'
+    return
+  fi
+  if [ "$reads" != "0" ] || [ "$writes" != "0" ]; then
+    printf 'instantaneous_io_nonzero'
+    return
+  fi
+  dependency_line="$(awk -F '\t' -v wanted="$table" '$1 == wanted { print; exit }' "$DEPENDENCY_CACHE_PATH")"
+  if [ -z "$dependency_line" ]; then
+    printf 'dependency_evidence_unavailable'
+    return
+  fi
+  dependency_total=0
+  while IFS= read -r value; do
+    if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+      printf 'dependency_evidence_unavailable'
+      return
+    fi
+    dependency_total=$((dependency_total + value))
+  done < <(printf '%s\n' "$dependency_line" | awk -F '\t' '{ for (i = 2; i <= NF; i++) print $i }')
+  if [ "$dependency_total" -ne 0 ]; then
+    printf 'database_dependencies_present'
+    return
+  fi
+}
+
+emit_simple_eligibility() {
+  local table="$1"
+  local repository_gate="$2"
+  local present blocker
+  present="$(table_present "$table")"
+  if [ "$present" != "1" ]; then
+    printf 'eligibility\t%s\tstate=already_absent\tevidence=instantaneous\n' "$table"
+    return
+  fi
+  blocker="$(common_retirement_blocker "$table")"
+  if [ -n "$blocker" ]; then
+    printf 'eligibility\t%s\tstate=blocked\treason=%s\tevidence=instantaneous\n' "$table" "$blocker"
+    return
+  fi
+  printf 'eligibility\t%s\tstate=eligible\trepository_gate=%s\tevidence=instantaneous\n' \
+    "$table" "$repository_gate"
+}
+
+emit_auth_account_eligibility() {
+  local present blocker state key value
+  present="$(table_present auth_accounts)"
+  if [ "$present" != "1" ]; then
+    printf 'eligibility\tauth_accounts\tstate=already_absent\tevidence=instantaneous\n'
+    return
+  fi
+  blocker="$(common_retirement_blocker auth_accounts)"
+  if [ -n "$blocker" ]; then
+    printf 'eligibility\tauth_accounts\tstate=blocked\treason=%s\tevidence=instantaneous\n' "$blocker"
+    return
+  fi
+  state="$(cached_parity_state auth_accounts_to_login_identities)"
+  if [ "$state" != "available" ]; then
+    printf 'eligibility\tauth_accounts\tstate=blocked\treason=account_parity_unavailable\tevidence=instantaneous\n'
+    return
+  fi
+  for key in invalid_supported_rows unsupported_rows missing_supported_rows mismatched_mapped_rows duplicate_mapped_rows; do
+    value="$(cached_parity_value auth_accounts_to_login_identities "$key")"
+    if [ -z "$value" ] || [ "$value" != "0" ]; then
+      printf 'eligibility\tauth_accounts\tstate=blocked\treason=account_parity_%s\tevidence=instantaneous\n' "$key"
+      return
+    fi
+  done
+  printf 'eligibility\tauth_accounts\tstate=eligible\trepository_gate=authn_retirement_migration\tevidence=instantaneous\n'
+}
+
+emit_auth_credential_eligibility() {
+  local present old_shape blocker state key value eligible mapped
+  present="$(table_present auth_credentials_legacy)"
+  if [ "$present" != "1" ]; then
+    old_shape="$(mysql_query "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'auth_credentials' AND COLUMN_NAME = 'account_id';")"
+    if [ "$old_shape" != "0" ]; then
+      printf 'eligibility\tauth_credentials_legacy\tstate=blocked\treason=old_shaped_auth_credentials_present\tevidence=instantaneous\n'
+    else
+      printf 'eligibility\tauth_credentials_legacy\tstate=already_absent\tevidence=instantaneous\n'
+    fi
+    return
+  fi
+  blocker="$(common_retirement_blocker auth_credentials_legacy)"
+  if [ -n "$blocker" ]; then
+    printf 'eligibility\tauth_credentials_legacy\tstate=blocked\treason=%s\tevidence=instantaneous\n' "$blocker"
+    return
+  fi
+  state="$(cached_parity_state legacy_credentials_to_authn)"
+  if [ "$state" != "available" ]; then
+    printf 'eligibility\tauth_credentials_legacy\tstate=blocked\treason=credential_parity_unavailable\tevidence=instantaneous\n'
+    return
+  fi
+  for key in password_unmapped_rows password_material_mismatches password_duplicate_mappings invalid_password_rows phone_blank_identifier_rows phone_orphan_account_rows phone_identity_mismatches phone_duplicate_mappings oauth_unmapped_rows unknown_credential_rows; do
+    value="$(cached_parity_value legacy_credentials_to_authn "$key")"
+    if [ -z "$value" ] || [ "$value" != "0" ]; then
+      printf 'eligibility\tauth_credentials_legacy\tstate=blocked\treason=credential_parity_%s\tevidence=instantaneous\n' "$key"
+      return
+    fi
+  done
+  for key in password phone oauth; do
+    case "$key" in
+      password)
+        eligible="$(cached_parity_value legacy_credentials_to_authn password_eligible_rows)"
+        mapped="$(cached_parity_value legacy_credentials_to_authn password_mapped_rows)"
+        ;;
+      phone)
+        eligible="$(cached_parity_value legacy_credentials_to_authn phone_eligible_rows)"
+        mapped="$(cached_parity_value legacy_credentials_to_authn phone_identity_mapped_rows)"
+        ;;
+      oauth)
+        eligible="$(cached_parity_value legacy_credentials_to_authn oauth_artifact_rows)"
+        mapped="$(cached_parity_value legacy_credentials_to_authn oauth_redundant_rows)"
+        ;;
+    esac
+    if [ -z "$eligible" ] || [ -z "$mapped" ] || [ "$eligible" != "$mapped" ]; then
+      printf 'eligibility\tauth_credentials_legacy\tstate=blocked\treason=credential_%s_count_mismatch\tevidence=instantaneous\n' "$key"
+      return
+    fi
+  done
+  printf 'eligibility\tauth_credentials_legacy\tstate=eligible\trepository_gate=authn_retirement_migration\tevidence=instantaneous\n'
+}
+
+emit_eligibility() {
+  local table present
+  for table in children guardianships; do
+    present="$(table_present "$table")"
+    if [ "$present" = "1" ]; then
+      printf 'eligibility\t%s\tstate=blocked\treason=requires_000019_execution\tevidence=instantaneous\n' "$table"
+    else
+      printf 'eligibility\t%s\tstate=already_absent\tevidence=instantaneous\n' "$table"
+    fi
+  done
+  emit_simple_eligibility schema_version retire_schema_version
+  emit_simple_eligibility tenants remove_bootstrap_reference
+  emit_simple_eligibility data_dictionary remove_bootstrap_reference
+  emit_auth_account_eligibility
+  emit_auth_credential_eligibility
+  for table in operation_logs audit_logs auth_token_audit; do
+    present="$(table_present "$table")"
+    if [ "$present" = "1" ]; then
+      printf 'eligibility\t%s\tstate=deferred\treason=product_or_compliance_decision\tevidence=instantaneous\n' "$table"
+    else
+      printf 'eligibility\t%s\tstate=already_absent\tevidence=instantaneous\n' "$table"
+    fi
+  done
 }
 
 main() {
@@ -307,15 +629,22 @@ main() {
   require_mysql8_client || return 1
   prepare_defaults_file
   ERROR_PATH="$(mktemp "${TMPDIR:-/tmp}/iam-retirement-error.XXXXXX")"
+  IO_CACHE_PATH="$(mktemp "${TMPDIR:-/tmp}/iam-retirement-io.XXXXXX")"
+  DEPENDENCY_CACHE_PATH="$(mktemp "${TMPDIR:-/tmp}/iam-retirement-dependencies.XXXXXX")"
+  PARITY_CACHE_PATH="$(mktemp "${TMPDIR:-/tmp}/iam-retirement-parity.XXXXXX")"
   chmod 0600 "$ERROR_PATH"
+  chmod 0600 "$IO_CACHE_PATH" "$DEPENDENCY_CACHE_PATH" "$PARITY_CACHE_PATH"
 
-  printf 'legacy_retirement_preflight\tformat_version=1\tquery_mode=read_only_aggregate\n'
+  printf 'legacy_retirement_preflight\tformat_version=2\tquery_mode=read_only_aggregate\n'
   emit_metadata
   emit_migration_state
   emit_candidate_tables
   emit_performance_schema_io
   emit_dependencies
+  emit_exact_row_counts
+  emit_schema_signatures
   emit_parity_summaries
+  emit_eligibility
   printf 'legacy_retirement_preflight\tresult=success\n'
 }
 

--- a/scripts/dbops/legacy-retirement-preflight.sh
+++ b/scripts/dbops/legacy-retirement-preflight.sh
@@ -7,12 +7,15 @@ ENVIRONMENT="${IAM_RETIREMENT_ENVIRONMENT:-}"
 COMMIT_SHA="${IAM_RETIREMENT_COMMIT_SHA:-}"
 IMAGE_SHA="${IAM_RETIREMENT_IMAGE_SHA:-unknown}"
 SUPPLIED_DEFAULTS="${IAM_RETIREMENT_MYSQL_DEFAULTS_FILE:-}"
+ALLOW_DOCKER_CLIENT="${IAM_RETIREMENT_ALLOW_DOCKER_CLIENT:-0}"
+MYSQL_CLIENT_IMAGE="${IAM_RETIREMENT_MYSQL_CLIENT_IMAGE:-mysql:8.0}"
 
 MYSQL_DEFAULTS=""
 ERROR_PATH=""
 IO_CACHE_PATH=""
 DEPENDENCY_CACHE_PATH=""
 PARITY_CACHE_PATH=""
+CLIENT_WRAPPER_DIR=""
 OWNS_DEFAULTS=0
 
 MIGRATION_PRESENT=0
@@ -43,6 +46,55 @@ cleanup() {
   if [ -n "$PARITY_CACHE_PATH" ]; then
     rm -f -- "$PARITY_CACHE_PATH"
   fi
+  if [ -n "$CLIENT_WRAPPER_DIR" ]; then
+    rm -f -- "$CLIENT_WRAPPER_DIR/mysql"
+    rmdir -- "$CLIENT_WRAPPER_DIR" 2>/dev/null || true
+  fi
+}
+
+prepare_container_client_fallback() {
+  local docker_bin sudo_bin wrapper
+  if command -v "$MYSQL_BIN" >/dev/null 2>&1; then
+    return
+  fi
+  if [ "$ALLOW_DOCKER_CLIENT" != "1" ]; then
+    return
+  fi
+  if ! [[ "$MYSQL_CLIENT_IMAGE" =~ ^[A-Za-z0-9._/@:-]+$ ]]; then
+    fail "MySQL client image is invalid"
+    return 1
+  fi
+  docker_bin="$(command -v "${IAM_RETIREMENT_DOCKER_BIN:-docker}" 2>/dev/null || true)"
+  sudo_bin="$(command -v "${IAM_RETIREMENT_SUDO_BIN:-sudo}" 2>/dev/null || true)"
+  if [ -z "$docker_bin" ] || [ -z "$sudo_bin" ] || ! "$sudo_bin" -n "$docker_bin" info >/dev/null 2>&1; then
+    fail "containerized MySQL client is unavailable"
+    return 1
+  fi
+
+  CLIENT_WRAPPER_DIR="$(mktemp -d "${TMPDIR:-/tmp}/iam-retirement-mysql-wrapper.XXXXXX")"
+  chmod 0700 "$CLIENT_WRAPPER_DIR"
+  export IAM_RETIREMENT_DOCKER_BIN="$docker_bin"
+  export IAM_RETIREMENT_SUDO_BIN="$sudo_bin"
+  export IAM_RETIREMENT_MYSQL_CLIENT_IMAGE="$MYSQL_CLIENT_IMAGE"
+  wrapper="$CLIENT_WRAPPER_DIR/mysql"
+  cat >"$wrapper" <<'EOF'
+#!/bin/sh
+set -eu
+defaults=""
+for argument in "$@"; do
+  case "$argument" in
+    --defaults-extra-file=*) defaults="${argument#*=}" ;;
+  esac
+done
+if [ -n "$defaults" ]; then
+  exec "$IAM_RETIREMENT_SUDO_BIN" -n "$IAM_RETIREMENT_DOCKER_BIN" run --rm -i --network host \
+    --volume "$defaults:$defaults:ro" "$IAM_RETIREMENT_MYSQL_CLIENT_IMAGE" mysql "$@"
+fi
+exec "$IAM_RETIREMENT_SUDO_BIN" -n "$IAM_RETIREMENT_DOCKER_BIN" run --rm -i --network host \
+  "$IAM_RETIREMENT_MYSQL_CLIENT_IMAGE" mysql "$@"
+EOF
+  chmod 0700 "$wrapper"
+  MYSQL_BIN="$wrapper"
 }
 
 trap cleanup EXIT
@@ -626,6 +678,7 @@ emit_eligibility() {
 main() {
   umask 077
   validate_configuration || return 1
+  prepare_container_client_fallback || return 1
   require_mysql8_client || return 1
   prepare_defaults_file
   ERROR_PATH="$(mktemp "${TMPDIR:-/tmp}/iam-retirement-error.XXXXXX")"

--- a/scripts/dbops/legacy-retirement-preflight.sh
+++ b/scripts/dbops/legacy-retirement-preflight.sh
@@ -88,10 +88,10 @@ for argument in "$@"; do
   esac
 done
 if [ -n "$defaults" ]; then
-  exec "$IAM_RETIREMENT_SUDO_BIN" -n "$IAM_RETIREMENT_DOCKER_BIN" run --rm -i --network host \
+  exec "$IAM_RETIREMENT_SUDO_BIN" -n "$IAM_RETIREMENT_DOCKER_BIN" run --rm --network host \
     --volume "$defaults:$defaults:ro" "$IAM_RETIREMENT_MYSQL_CLIENT_IMAGE" mysql "$@"
 fi
-exec "$IAM_RETIREMENT_SUDO_BIN" -n "$IAM_RETIREMENT_DOCKER_BIN" run --rm -i --network host \
+exec "$IAM_RETIREMENT_SUDO_BIN" -n "$IAM_RETIREMENT_DOCKER_BIN" run --rm --network host \
   "$IAM_RETIREMENT_MYSQL_CLIENT_IMAGE" mysql "$@"
 EOF
   chmod 0700 "$wrapper"

--- a/scripts/dbops/legacy-retirement-preflight.sh
+++ b/scripts/dbops/legacy-retirement-preflight.sh
@@ -9,6 +9,7 @@ IMAGE_SHA="${IAM_RETIREMENT_IMAGE_SHA:-unknown}"
 SUPPLIED_DEFAULTS="${IAM_RETIREMENT_MYSQL_DEFAULTS_FILE:-}"
 ALLOW_DOCKER_CLIENT="${IAM_RETIREMENT_ALLOW_DOCKER_CLIENT:-0}"
 MYSQL_CLIENT_IMAGE="${IAM_RETIREMENT_MYSQL_CLIENT_IMAGE:-mysql:8.0}"
+RETIREMENT_SCOPE="${IAM_RETIREMENT_SCOPE:-all}"
 
 MYSQL_DEFAULTS=""
 ERROR_PATH=""
@@ -128,6 +129,10 @@ validate_configuration() {
   require_value MYSQL_DBNAME "${MYSQL_DBNAME:-}" || return 1
   validate_label IAM_RETIREMENT_ENVIRONMENT "$ENVIRONMENT" || return 1
   validate_label IAM_RETIREMENT_IMAGE_SHA "$IMAGE_SHA" || return 1
+  case "$RETIREMENT_SCOPE" in
+    all|identity|schema_version|platform|authn) ;;
+    *) fail "retirement scope is invalid"; return 1 ;;
+  esac
   if ! [[ "$MYSQL_DBNAME" =~ ^[A-Za-z0-9_]+$ ]]; then
     fail "database name is invalid"
     return 1
@@ -155,6 +160,29 @@ validate_configuration() {
   fi
   [ -n "$COMMIT_SHA" ] || COMMIT_SHA="unknown"
   validate_label IAM_RETIREMENT_COMMIT_SHA "$COMMIT_SHA" || return 1
+}
+
+emit_identity_schema_contracts() {
+  local table expected expected_count quoted result present_count present_columns
+  while IFS='|' read -r table expected; do
+    expected_count="$(awk -F ',' '{ print NF }' <<<"$expected")"
+    quoted="${expected//,/','}"
+    result="$(mysql_query "SELECT
+      COUNT(*),
+      COALESCE(GROUP_CONCAT(COLUMN_NAME ORDER BY ORDINAL_POSITION SEPARATOR ','), 'none')
+      FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = '$table'
+        AND COLUMN_NAME IN ('$quoted');")"
+    IFS=$'\t' read -r present_count present_columns <<<"$result"
+    printf 'schema_contract\t%s\texpected_columns=%s\tpresent_columns=%s\tpresent_required=%s\n' \
+      "$table" "$expected_count" "$present_count" "$present_columns"
+  done <<'EOF'
+children|id,name,id_card,gender,birthday,height,weight,created_at,updated_at,deleted_at,created_by,updated_by,deleted_by,version
+profiles|id,name,id_card,gender,birthday,height,weight,created_at,updated_at,deleted_at,created_by,updated_by,deleted_by,version
+guardianships|id,user_id,child_id,relation,established_at,revoked_at,created_at,updated_at,deleted_at,created_by,updated_by,deleted_by,version
+profile_links|id,user_id,profile_id,type,relation,established_at,revoked_at,created_at,updated_at,deleted_at,created_by,updated_by,deleted_by,version
+EOF
 }
 
 require_mysql8_client() {
@@ -352,7 +380,9 @@ emit_parity_result() {
 }
 
 emit_parity_summaries() {
-  emit_parity_result children_to_profiles "children profiles" "SELECT
+  if [ "$RETIREMENT_SCOPE" = "all" ] || [ "$RETIREMENT_SCOPE" = "identity" ]; then
+    emit_identity_schema_contracts
+    emit_parity_result children_to_profiles "children profiles" "SELECT
     CONCAT('legacy_rows=', COUNT(*)),
     CONCAT('mapped_rows=', COALESCE(SUM(p.id IS NOT NULL), 0)),
     CONCAT('missing_rows=', COALESCE(SUM(p.id IS NULL), 0)),
@@ -362,7 +392,7 @@ emit_parity_summaries() {
       p.deleted_at <=> c.deleted_at AND p.version <=> c.version)), 0))
     FROM children c LEFT JOIN profiles p ON p.id = c.id;"
 
-  emit_parity_result guardianships_to_profile_links "guardianships profile_links" "SELECT
+    emit_parity_result guardianships_to_profile_links "guardianships profile_links" "SELECT
     CONCAT('legacy_rows=', COUNT(*)),
     CONCAT('mapped_rows=', COALESCE(SUM(p.id IS NOT NULL), 0)),
     CONCAT('missing_rows=', COALESCE(SUM(p.id IS NULL), 0)),
@@ -372,8 +402,10 @@ emit_parity_summaries() {
       p.relation <=> CASE LOWER(TRIM(g.relation)) WHEN 'self' THEN 'self' WHEN 'parent' THEN 'parent' WHEN 'grandparent' THEN 'grandparent' ELSE 'other' END AND
       p.revoked_at <=> g.revoked_at AND p.deleted_at <=> g.deleted_at AND p.version <=> g.version)), 0))
     FROM guardianships g LEFT JOIN profile_links p ON p.id = g.id;"
+  fi
 
-  emit_parity_result auth_accounts_to_login_identities "auth_accounts auth_login_identities" "WITH account_facts AS (
+  if [ "$RETIREMENT_SCOPE" = "all" ] || [ "$RETIREMENT_SCOPE" = "authn" ]; then
+    emit_parity_result auth_accounts_to_login_identities "auth_accounts auth_login_identities" "WITH account_facts AS (
     SELECT a.*,
       a.type IN ('opera', 'mock-consumer', 'wc-minip', 'wc-com') AS supported,
       (TRIM(a.external_id) <> '' AND (a.type NOT IN ('wc-minip', 'wc-com') OR TRIM(COALESCE(a.app_id, '')) <> '')) AS valid_key,
@@ -406,7 +438,7 @@ emit_parity_summaries() {
     CONCAT('duplicate_mapped_rows=', COALESCE(SUM(supported AND valid_key AND mapping_count > 1), 0))
   FROM account_facts;"
 
-  emit_parity_result legacy_credentials_to_authn "auth_credentials_legacy auth_credentials auth_login_identities auth_accounts" "WITH credential_facts AS (
+    emit_parity_result legacy_credentials_to_authn "auth_credentials_legacy auth_credentials auth_login_identities auth_accounts" "WITH credential_facts AS (
     SELECT lc.*,
       ((lc.type = 'password' OR COALESCE(lc.idp, '') = '')
         AND COALESCE(OCTET_LENGTH(lc.material), 0) > 0 AND COALESCE(lc.algo, '') <> '') AS password_eligible,
@@ -478,6 +510,7 @@ emit_parity_summaries() {
     CONCAT('oauth_unmapped_rows=', COALESCE(SUM(oauth_artifact AND NOT oauth_identity_exists), 0)),
     CONCAT('unknown_credential_rows=', COALESCE(SUM(NOT password_eligible AND NOT invalid_password AND NOT phone_artifact AND NOT oauth_artifact), 0))
   FROM credential_facts;"
+  fi
 }
 
 cached_parity_state() {
@@ -660,11 +693,25 @@ emit_eligibility() {
       printf 'eligibility\t%s\tstate=already_absent\tevidence=instantaneous\n' "$table"
     fi
   done
-  emit_simple_eligibility schema_version retire_schema_version
-  emit_simple_eligibility tenants remove_bootstrap_reference
-  emit_simple_eligibility data_dictionary remove_bootstrap_reference
-  emit_auth_account_eligibility
-  emit_auth_credential_eligibility
+  if [ "$RETIREMENT_SCOPE" = "all" ] || [ "$RETIREMENT_SCOPE" = "schema_version" ]; then
+    emit_simple_eligibility schema_version retire_schema_version
+  else
+    printf 'eligibility\tschema_version\tstate=not_evaluated\treason=scope_excluded\n'
+  fi
+  if [ "$RETIREMENT_SCOPE" = "all" ] || [ "$RETIREMENT_SCOPE" = "platform" ]; then
+    emit_simple_eligibility tenants remove_bootstrap_reference
+    emit_simple_eligibility data_dictionary remove_bootstrap_reference
+  else
+    printf 'eligibility\ttenants\tstate=not_evaluated\treason=scope_excluded\n'
+    printf 'eligibility\tdata_dictionary\tstate=not_evaluated\treason=scope_excluded\n'
+  fi
+  if [ "$RETIREMENT_SCOPE" = "all" ] || [ "$RETIREMENT_SCOPE" = "authn" ]; then
+    emit_auth_account_eligibility
+    emit_auth_credential_eligibility
+  else
+    printf 'eligibility\tauth_accounts\tstate=not_evaluated\treason=scope_excluded\n'
+    printf 'eligibility\tauth_credentials_legacy\tstate=not_evaluated\treason=scope_excluded\n'
+  fi
   for table in operation_logs audit_logs auth_token_audit; do
     present="$(table_present "$table")"
     if [ "$present" = "1" ]; then
@@ -688,7 +735,7 @@ main() {
   chmod 0600 "$ERROR_PATH"
   chmod 0600 "$IO_CACHE_PATH" "$DEPENDENCY_CACHE_PATH" "$PARITY_CACHE_PATH"
 
-  printf 'legacy_retirement_preflight\tformat_version=2\tquery_mode=read_only_aggregate\n'
+  printf 'legacy_retirement_preflight\tformat_version=2\tquery_mode=read_only_aggregate\tscope=%s\n' "$RETIREMENT_SCOPE"
   emit_metadata
   emit_migration_state
   emit_candidate_tables

--- a/scripts/dbops/legacy-retirement-preflight.sh
+++ b/scripts/dbops/legacy-retirement-preflight.sh
@@ -163,20 +163,18 @@ validate_configuration() {
 }
 
 emit_identity_schema_contracts() {
-  local table expected expected_count quoted result present_count present_columns
+  local table expected expected_count result actual_count actual_columns
   while IFS='|' read -r table expected; do
     expected_count="$(awk -F ',' '{ print NF }' <<<"$expected")"
-    quoted="${expected//,/','}"
     result="$(mysql_query "SELECT
       COUNT(*),
       COALESCE(GROUP_CONCAT(COLUMN_NAME ORDER BY ORDINAL_POSITION SEPARATOR ','), 'none')
       FROM information_schema.COLUMNS
       WHERE TABLE_SCHEMA = DATABASE()
-        AND TABLE_NAME = '$table'
-        AND COLUMN_NAME IN ('$quoted');")"
-    IFS=$'\t' read -r present_count present_columns <<<"$result"
-    printf 'schema_contract\t%s\texpected_columns=%s\tpresent_columns=%s\tpresent_required=%s\n' \
-      "$table" "$expected_count" "$present_count" "$present_columns"
+        AND TABLE_NAME = '$table';")"
+    IFS=$'\t' read -r actual_count actual_columns <<<"$result"
+    printf 'schema_contract\t%s\texpected_columns=%s\tactual_columns=%s\tcolumn_names=%s\n' \
+      "$table" "$expected_count" "$actual_count" "$actual_columns"
   done <<'EOF'
 children|id,name,id_card,gender,birthday,height,weight,created_at,updated_at,deleted_at,created_by,updated_by,deleted_by,version
 profiles|id,name,id_card,gender,birthday,height,weight,created_at,updated_at,deleted_at,created_by,updated_by,deleted_by,version

--- a/scripts/dbops/legacy_retirement_preflight_test.go
+++ b/scripts/dbops/legacy_retirement_preflight_test.go
@@ -17,6 +17,7 @@ func TestLegacyRetirementPreflightIsReadOnlyAndCoversRetirementEvidence(t *testi
 	source := string(data)
 
 	for _, required := range []string{
+		"format_version=2",
 		"schema_migrations",
 		"performance_schema.table_io_waits_summary_by_table",
 		"information_schema.KEY_COLUMN_USAGE",
@@ -30,6 +31,13 @@ func TestLegacyRetirementPreflightIsReadOnlyAndCoversRetirementEvidence(t *testi
 		"legacy_credentials_to_authn",
 		"mismatched_mapped_rows",
 		"password_material_mismatches",
+		"invalid_supported_rows",
+		"unsupported_rows",
+		"oauth_unmapped_rows",
+		"unknown_credential_rows",
+		"schema_signature",
+		"exact_rows",
+		"eligibility",
 		"zero_io_interpretation=not_proof_without_full_observation_window",
 		"--defaults-extra-file=",
 	} {
@@ -75,21 +83,25 @@ for arg in "$@"; do
   esac
 done
 [ -n "$defaults" ]
-[ "$(stat -f %Lp "$defaults" 2>/dev/null || stat -c %a "$defaults")" = "600" ]
+[ "$(stat -c %a "$defaults" 2>/dev/null || stat -f %Lp "$defaults")" = "600" ]
 grep -q "password=db-ops-password-sentinel" "$defaults"
 case "$*" in
   *"SELECT VERSION()"*) printf "8.0.36\tMySQL Community Server\t2026-08-07T00:00:00Z\n" ;;
-  *"MAX(version)"*) printf "18\t0\t1\n" ;;
+  *"MAX(version)"*) printf "21\t${FAKE_MIGRATION_DIRTY:-0}\t1\n" ;;
   *"MAX(TABLE_ROWS)"*) printf "1\t4\t4096\t2026-08-06T00:00:00Z\n" ;;
   *"@@performance_schema"*) printf "1\n" ;;
   *"performance_schema.global_status"*) printf "86400\n" ;;
-  *"table_io_waits_summary_by_table"*) printf "0\t0\t0\t0\n" ;;
+  *"table_io_waits_summary_by_table"*) printf "0\t0\t${FAKE_IO_READS:-0}\t0\n" ;;
   *"information_schema.KEY_COLUMN_USAGE"*) printf "0\t0\t0\t0\t0\t0\t0\t0\n" ;;
+  *"TABLE_NAME = 'auth_credentials' AND COLUMN_NAME = 'account_id'"*) printf "0\n" ;;
+  *"information_schema.COLUMNS"*) printf "12\t0123456789abcdef\n" ;;
+  *"information_schema.STATISTICS"*) printf "4\tfedcba9876543210\n" ;;
   *"FROM children c"*) printf "legacy_rows=4\tmapped_rows=4\tmissing_rows=0\tmismatched_rows=0\n" ;;
   *"FROM guardianships g"*) printf "legacy_rows=3\tmapped_rows=3\tmissing_rows=0\tmismatched_rows=0\n" ;;
-  *"FROM auth_accounts a"*) printf "legacy_rows=2\tsupported_rows=2\tmapped_rows=2\tmissing_supported_rows=0\tmismatched_mapped_rows=0\n" ;;
-  *"FROM auth_credentials_legacy lc"*) printf "legacy_rows=2\tpassword_eligible_rows=1\tpassword_mapped_rows=1\tpassword_material_mismatches=0\tphone_eligible_rows=1\tphone_identity_mapped_rows=1\n" ;;
+  *"FROM auth_credentials_legacy lc"*) printf "legacy_rows=3\tpassword_eligible_rows=1\tpassword_mapped_rows=1\tpassword_unmapped_rows=0\tpassword_material_mismatches=0\tpassword_duplicate_mappings=0\tinvalid_password_rows=0\tphone_eligible_rows=1\tphone_identity_mapped_rows=1\tphone_blank_identifier_rows=0\tphone_orphan_account_rows=0\tphone_identity_mismatches=0\tphone_duplicate_mappings=0\toauth_artifact_rows=1\toauth_redundant_rows=1\toauth_unmapped_rows=0\tunknown_credential_rows=0\n" ;;
+  *"FROM auth_accounts a"*) printf "legacy_rows=2\tsupported_rows=2\tvalid_supported_rows=2\tinvalid_supported_rows=0\tunsupported_rows=0\tmapped_rows=2\tmissing_supported_rows=0\tmismatched_mapped_rows=0\tduplicate_mapped_rows=0\n" ;;
   *"information_schema.TABLES"*) printf "1\n" ;;
+  *"SELECT COUNT(*) FROM "*) printf "4\n" ;;
   *) exit 81 ;;
 esac
 `
@@ -118,13 +130,20 @@ esac
 	for _, required := range []string{
 		"query_mode=read_only_aggregate",
 		"metadata\tenvironment\tstaging",
-		"migration\tschema_migrations\tpresent\tversion=18\tdirty=0",
+		"format_version=2",
+		"migration\tschema_migrations\tpresent\tversion=21\tdirty=0",
 		"candidate_table\tchildren\tpresent=1",
 		"performance_schema\tstate=enabled",
 		"table_io\tchildren\tcount_star=0",
 		"dependency\tchildren\tfk=0",
+		"exact_rows\tchildren\tstate=available\trows=4",
+		"schema_signature\tchildren\tstate=available",
 		"parity\tchildren_to_profiles\tstate=available\tlegacy_rows=4",
 		"password_material_mismatches=0",
+		"eligibility\tschema_version\tstate=eligible",
+		"eligibility\tauth_accounts\tstate=eligible",
+		"eligibility\tauth_credentials_legacy\tstate=eligible",
+		"eligibility\taudit_logs\tstate=deferred",
 		"legacy_retirement_preflight\tresult=success",
 	} {
 		if !strings.Contains(text, required) {
@@ -135,5 +154,23 @@ esac
 	requireNoError(t, err)
 	if len(leftovers) != 0 {
 		t.Fatalf("preflight left credential/error files: %v", leftovers)
+	}
+
+	dirtyCmd := exec.Command("/bin/bash", script)
+	dirtyCmd.Env = append(cmd.Env, "FAKE_MIGRATION_DIRTY=1")
+	dirtyOutput, err := dirtyCmd.CombinedOutput()
+	requireNoError(t, err)
+	assertSafeOutput(t, string(dirtyOutput))
+	if !strings.Contains(string(dirtyOutput), "eligibility\tschema_version\tstate=blocked\treason=schema_migrations_dirty") {
+		t.Fatalf("dirty migration did not fail eligibility closed:\n%s", dirtyOutput)
+	}
+
+	ioCmd := exec.Command("/bin/bash", script)
+	ioCmd.Env = append(cmd.Env, "FAKE_IO_READS=1")
+	ioOutput, err := ioCmd.CombinedOutput()
+	requireNoError(t, err)
+	assertSafeOutput(t, string(ioOutput))
+	if !strings.Contains(string(ioOutput), "eligibility\tschema_version\tstate=blocked\treason=instantaneous_io_nonzero") {
+		t.Fatalf("nonzero I/O did not fail eligibility closed:\n%s", ioOutput)
 	}
 }

--- a/scripts/dbops/legacy_retirement_preflight_test.go
+++ b/scripts/dbops/legacy_retirement_preflight_test.go
@@ -40,6 +40,8 @@ func TestLegacyRetirementPreflightIsReadOnlyAndCoversRetirementEvidence(t *testi
 		"eligibility",
 		"zero_io_interpretation=not_proof_without_full_observation_window",
 		"--defaults-extra-file=",
+		"IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
+		"mysql:8.0",
 	} {
 		if !strings.Contains(source, required) {
 			t.Fatalf("preflight is missing evidence contract %q", required)

--- a/scripts/dbops/legacy_retirement_preflight_test.go
+++ b/scripts/dbops/legacy_retirement_preflight_test.go
@@ -42,6 +42,8 @@ func TestLegacyRetirementPreflightIsReadOnlyAndCoversRetirementEvidence(t *testi
 		"--defaults-extra-file=",
 		"IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
 		"mysql:8.0",
+		"IAM_RETIREMENT_SCOPE",
+		"schema_contract",
 	} {
 		if !strings.Contains(source, required) {
 			t.Fatalf("preflight is missing evidence contract %q", required)
@@ -140,6 +142,7 @@ esac
 		"dependency\tchildren\tfk=0",
 		"exact_rows\tchildren\tstate=available\trows=4",
 		"schema_signature\tchildren\tstate=available",
+		"schema_contract\tchildren\texpected_columns=14",
 		"parity\tchildren_to_profiles\tstate=available\tlegacy_rows=4",
 		"password_material_mismatches=0",
 		"eligibility\tschema_version\tstate=eligible",
@@ -174,5 +177,14 @@ esac
 	assertSafeOutput(t, string(ioOutput))
 	if !strings.Contains(string(ioOutput), "eligibility\tschema_version\tstate=blocked\treason=instantaneous_io_nonzero") {
 		t.Fatalf("nonzero I/O did not fail eligibility closed:\n%s", ioOutput)
+	}
+
+	identityCmd := exec.Command("/bin/bash", script)
+	identityCmd.Env = append(cmd.Env, "IAM_RETIREMENT_SCOPE=identity")
+	identityOutput, err := identityCmd.CombinedOutput()
+	requireNoError(t, err)
+	assertSafeOutput(t, string(identityOutput))
+	if !strings.Contains(string(identityOutput), "scope=identity") || strings.Contains(string(identityOutput), "parity\tauth_accounts_to_login_identities") {
+		t.Fatalf("identity scope executed an unrelated AuthN parity query:\n%s", identityOutput)
 	}
 }


### PR DESCRIPTION
## What changed

- upgrades the secret-safe legacy retirement preflight to format v2 and adds scoped status runs
- adds MySQL 8 container-client fallback for production database operations
- adds production-environment dry-run/apply operations for direct children/guardianships retirement
- requires version 18 clean, a named backup no older than two hours, zero database-owned dependencies, and an exact confirmation token
- performs no canonical writes and deletes both legacy tables in one final DROP
- makes the MySQL fixture collation explicit and adds a real MySQL 8 backup/restore/retirement gate

## Why

Production is still at migration 18. The owner explicitly waived children/guardianships reconciliation and authorized direct deletion. The oneoff must delete the old tables first so the already-published migration 19 can execute idempotently without touching its historical SQL.

## Validation

- bash syntax checks for database operation and preflight scripts
- go test ./scripts/dbops ./scripts/oneoff ./internal/pkg/migration -count=1
- isolated MySQL 8 backup, dry-run, apply, and postcondition verification
- go test ./...
- go vet ./...
- python3 scripts/check-docs-facts.py
- make docs-hygiene

## Release gate

Keep this PR draft until CI is green, production backup and dry-run succeed, and the direct oneoff reports both tables removed while schema_migrations remains version 18 clean. Then merge this batch only, deploy migration 19, and verify version 19 clean before publishing migrations 20 or 21.