### PR TITLE
feat(dbops): report Performance Schema capabilities

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -139,6 +139,7 @@ go test ./internal/pkg/migration -run "TestJWKSSingleActiveMigrationMySQL" -v -c
 - `backup`: 备份 MySQL，保留最近 3 份。
 - `restore`: 从 `iam_backup_YYYYMMDD_HHMMSS.sql.gz` 恢复。
 - `status`: 只输出 MySQL 客户端版本、连接状态、库总大小、表数量、备份数量和最新备份时间。
+- `performance-schema-status`: 只读输出启用状态、持久化加载、TLS/X.509 前置条件、可见权限和数据库部署类型分类，不输出账号、地址或 grant 原文。
 - `retire-identity-dry-run`: 校验版本 18 clean、指定备份新鲜且完整、两张旧表同时存在及数据库对象零依赖，不写数据库。
 - `retire-identity-apply`: 在相同门禁和生产 environment 下，要求确认令牌 `RETIRE_CHILDREN_GUARDIANSHIPS`，用最终一条 DROP 同时删除 `children/guardianships`。
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -139,7 +139,7 @@ go test ./internal/pkg/migration -run "TestJWKSSingleActiveMigrationMySQL" -v -c
 - `backup`: 备份 MySQL，保留最近 3 份。
 - `restore`: 从 `iam_backup_YYYYMMDD_HHMMSS.sql.gz` 恢复。
 - `status`: 只输出 MySQL 客户端版本、连接状态、库总大小、表数量、备份数量和最新备份时间。
-- `performance-schema-status`: 只读输出启用状态、持久化加载、TLS/X.509 前置条件、可见权限和数据库部署类型分类，不输出账号、地址或 grant 原文。
+- `performance-schema-status`: 只读输出启用状态、持久化加载、TLS/X.509 前置条件、可见权限、数据库部署类型和端点供应商分类，不输出账号、地址或 grant 原文。
 - `retire-identity-dry-run`: 校验版本 18 clean、指定备份新鲜且完整、两张旧表同时存在及数据库对象零依赖，不写数据库。
 - `retire-identity-apply`: 在相同门禁和生产 environment 下，要求确认令牌 `RETIRE_CHILDREN_GUARDIANSHIPS`，用最终一条 DROP 同时删除 `children/guardianships`。
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -139,7 +139,7 @@ go test ./internal/pkg/migration -run "TestJWKSSingleActiveMigrationMySQL" -v -c
 - `backup`: 备份 MySQL，保留最近 3 份。
 - `restore`: 从 `iam_backup_YYYYMMDD_HHMMSS.sql.gz` 恢复。
 - `status`: 只输出 MySQL 客户端版本、连接状态、库总大小、表数量、备份数量和最新备份时间。
-- `performance-schema-status`: 只读输出启用状态、持久化加载、TLS/X.509 前置条件、可见权限、数据库部署类型和端点供应商分类，不输出账号、地址或 grant 原文。
+- `performance-schema-status`: 只读输出启用状态、持久化加载、TLS/X.509 前置条件、可见权限、数据库部署类型、端点供应商分类，以及表 I/O 汇总契约和只读访问能力；不输出账号、地址、grant 原文或数据库错误详情。
 - `retire-identity-dry-run`: 校验版本 18 clean、指定备份新鲜且完整、两张旧表同时存在及数据库对象零依赖，不写数据库。
 - `retire-identity-apply`: 在相同门禁和生产 environment 下，要求确认令牌 `RETIRE_CHILDREN_GUARDIANSHIPS`，用最终一条 DROP 同时删除 `children/guardianships`。
 

--- a/.github/workflows/db-ops.yml
+++ b/.github/workflows/db-ops.yml
@@ -17,6 +17,7 @@ on:
           - backup
           - restore
           - status
+          - performance-schema-status
           - retire-identity-dry-run
           - retire-identity-apply
       backup_name:
@@ -152,9 +153,9 @@ jobs:
           envs: IAM_RETIREMENT_ENVIRONMENT,IAM_RETIREMENT_ALLOW_DOCKER_CLIENT,IAM_RETIREMENT_COMMIT_SHA,IAM_RETIREMENT_IMAGE_SHA,IAM_RETIREMENT_SCOPE,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
           script_path: scripts/dbops/legacy-retirement-preflight.sh
 
-  db-identity-retirement:
-    name: Retire Legacy Identity Tables
-    if: github.event.inputs.operation == 'retire-identity-dry-run' || github.event.inputs.operation == 'retire-identity-apply'
+  db-controlled-operation:
+    name: Controlled Database Operation
+    if: github.event.inputs.operation == 'retire-identity-dry-run' || github.event.inputs.operation == 'retire-identity-apply' || github.event.inputs.operation == 'performance-schema-status'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -166,7 +167,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Validate or retire children and guardianships
+      - name: Run controlled database operation
         uses: appleboy/ssh-action@v1.2.5
         env:
           IAM_DB_OPS_OPERATION: ${{ github.event.inputs.operation }}

--- a/scripts/check-docs-facts.py
+++ b/scripts/check-docs-facts.py
@@ -372,6 +372,7 @@ def check_database_operations_facts() -> None:
         "IAM_RETIREMENT_SCOPE",
         "retire-identity-dry-run",
         "retire-identity-apply",
+        "performance-schema-status",
         "IAM_DB_OPS_CONFIRMATION",
     ):
         if token not in workflow:
@@ -396,6 +397,8 @@ def check_database_operations_facts() -> None:
         "RETIRE_CHILDREN_GUARDIANSHIPS",
         "DROP TABLE children, guardianships;",
         "canonical_writes=0",
+        "performance schema capability:",
+        "configure_provider_or_server_startup",
     ):
         if token not in script:
             fail(f"database operation script is missing safety contract {token}")

--- a/scripts/check-docs-facts.py
+++ b/scripts/check-docs-facts.py
@@ -398,6 +398,7 @@ def check_database_operations_facts() -> None:
         "DROP TABLE children, guardianships;",
         "canonical_writes=0",
         "performance schema capability:",
+        "endpoint_provider=",
         "configure_provider_or_server_startup",
     ):
         if token not in script:

--- a/scripts/dbops/database-operation.sh
+++ b/scripts/dbops/database-operation.sh
@@ -599,9 +599,11 @@ performance_schema_status() {
   IFS=$'\t' read -r enabled persisted_load x509_configured tls_active server_flavor server_version <<<"$state"
   echo "performance schema capability: result=success enabled=$enabled persisted_globals_load=$persisted_load persist_x509_subject_configured=$x509_configured tls_active=$tls_active persist_privileges=$privilege_state server_flavor=$server_flavor endpoint_provider=$endpoint_provider server_version=$server_version"
 
-  local table_io_contract table_io_probe table_io_select
+  local table_io_contract table_io_probe table_io_select table_io_exists table_io_required_columns
   table_io_contract="unavailable"
   table_io_select="not_checked"
+  table_io_exists="unknown"
+  table_io_required_columns="unknown"
   if table_io_probe="$(mysql_scalar "SELECT
       EXISTS(SELECT 1 FROM information_schema.TABLES
         WHERE TABLE_SCHEMA = 'performance_schema'
@@ -610,18 +612,21 @@ performance_schema_status() {
         WHERE TABLE_SCHEMA = 'performance_schema'
           AND TABLE_NAME = 'table_io_waits_summary_by_table'
           AND COLUMN_NAME IN ('COUNT_STAR', 'SUM_TIMER_WAIT', 'COUNT_READ', 'COUNT_WRITE'));" )" \
-      && [ "$table_io_probe" = $'1\t4' ]; then
-    table_io_contract="valid"
-    if table_io_probe="$(mysql_scalar "SELECT COUNT(*) FROM performance_schema.table_io_waits_summary_by_table;")" \
-        && [[ "$table_io_probe" =~ ^[0-9]+$ ]]; then
-      table_io_select="available"
+      && [[ "$table_io_probe" =~ ^[01]$'\t'[0-9]+$ ]]; then
+    IFS=$'\t' read -r table_io_exists table_io_required_columns <<<"$table_io_probe"
+    if [ "$table_io_exists" = "1" ] && [ "$table_io_required_columns" = "4" ]; then
+      table_io_contract="valid"
+      if table_io_probe="$(mysql_scalar "SELECT COUNT(*) FROM performance_schema.table_io_waits_summary_by_table;")" \
+          && [[ "$table_io_probe" =~ ^[0-9]+$ ]]; then
+        table_io_select="available"
+      else
+        table_io_select="unavailable"
+      fi
     else
-      table_io_select="unavailable"
+      table_io_contract="invalid"
     fi
-  elif [ -n "$table_io_probe" ]; then
-    table_io_contract="invalid"
   fi
-  echo "performance schema capability: table_io_contract=$table_io_contract table_io_select=$table_io_select"
+  echo "performance schema capability: table_io_contract=$table_io_contract table_io_table_exists=$table_io_exists table_io_required_columns=$table_io_required_columns table_io_select=$table_io_select"
 
   if [ "$enabled" = "1" ]; then
     echo "performance schema capability: next_action=already_enabled restart_required=0"

--- a/scripts/dbops/database-operation.sh
+++ b/scripts/dbops/database-operation.sh
@@ -599,10 +599,10 @@ performance_schema_status() {
   IFS=$'\t' read -r enabled persisted_load x509_configured tls_active server_flavor server_version <<<"$state"
   echo "performance schema capability: result=success enabled=$enabled persisted_globals_load=$persisted_load persist_x509_subject_configured=$x509_configured tls_active=$tls_active persist_privileges=$privilege_state server_flavor=$server_flavor endpoint_provider=$endpoint_provider server_version=$server_version"
 
-  local table_io_contract table_io_probe table_io_select table_io_exists table_io_required_columns
+  local table_io_contract table_io_probe table_io_select table_io_metadata_visible table_io_required_columns
   table_io_contract="unavailable"
   table_io_select="not_checked"
-  table_io_exists="unknown"
+  table_io_metadata_visible="unknown"
   table_io_required_columns="unknown"
   if table_io_probe="$(mysql_scalar "SELECT
       EXISTS(SELECT 1 FROM information_schema.TABLES
@@ -613,20 +613,20 @@ performance_schema_status() {
           AND TABLE_NAME = 'table_io_waits_summary_by_table'
           AND COLUMN_NAME IN ('COUNT_STAR', 'SUM_TIMER_WAIT', 'COUNT_READ', 'COUNT_WRITE'));" )" \
       && [[ "$table_io_probe" =~ ^[01]$'\t'[0-9]+$ ]]; then
-    IFS=$'\t' read -r table_io_exists table_io_required_columns <<<"$table_io_probe"
-    if [ "$table_io_exists" = "1" ] && [ "$table_io_required_columns" = "4" ]; then
+    IFS=$'\t' read -r table_io_metadata_visible table_io_required_columns <<<"$table_io_probe"
+    if [ "$table_io_metadata_visible" = "1" ] && [ "$table_io_required_columns" = "4" ]; then
       table_io_contract="valid"
-      if table_io_probe="$(mysql_scalar "SELECT COUNT(*) FROM performance_schema.table_io_waits_summary_by_table;")" \
-          && [[ "$table_io_probe" =~ ^[0-9]+$ ]]; then
-        table_io_select="available"
-      else
-        table_io_select="unavailable"
-      fi
     else
       table_io_contract="invalid"
     fi
   fi
-  echo "performance schema capability: table_io_contract=$table_io_contract table_io_table_exists=$table_io_exists table_io_required_columns=$table_io_required_columns table_io_select=$table_io_select"
+  if table_io_probe="$(mysql_scalar "SELECT COUNT(*) FROM performance_schema.table_io_waits_summary_by_table;")" \
+      && [[ "$table_io_probe" =~ ^[0-9]+$ ]]; then
+    table_io_select="available"
+  else
+    table_io_select="unavailable"
+  fi
+  echo "performance schema capability: table_io_contract=$table_io_contract table_io_metadata_visible=$table_io_metadata_visible table_io_required_columns=$table_io_required_columns table_io_select=$table_io_select"
 
   if [ "$enabled" = "1" ]; then
     echo "performance schema capability: next_action=already_enabled restart_required=0"

--- a/scripts/dbops/database-operation.sh
+++ b/scripts/dbops/database-operation.sh
@@ -126,7 +126,7 @@ require_value() {
 
 validate_configuration() {
   case "$OPERATION" in
-    backup|restore|status|retire-identity-dry-run|retire-identity-apply) ;;
+    backup|restore|status|retire-identity-dry-run|retire-identity-apply|performance-schema-status) ;;
     *) fail "unsupported operation"; return 1 ;;
   esac
 
@@ -552,6 +552,52 @@ SQL
   echo "identity retirement completed: mode=apply result=success children_rows_deleted=$children_rows guardianships_rows_deleted=$guardianship_rows canonical_writes=0"
 }
 
+performance_schema_status() {
+  require_mysql8_client "$MYSQL_BIN" mysql || return 1
+  prepare_backup_directory || return 1
+  prepare_defaults_file
+  ERROR_PATH="$BACKUP_DIR/.iam_performance_schema_status.error"
+
+  local state grants privilege_state
+  if ! state="$(mysql_scalar "SELECT
+      @@performance_schema + 0,
+      @@persisted_globals_load + 0,
+      IF(TRIM(@@persist_only_admin_x509_subject) = '', 0, 1),
+      COALESCE((SELECT MAX(VARIABLE_VALUE <> '') FROM performance_schema.session_status WHERE VARIABLE_NAME = 'Ssl_cipher'), 0),
+      CASE
+        WHEN LOWER(@@version_comment) REGEXP 'alibaba|rds|aurora|cloud sql|heatwave' THEN 'managed_or_cloud'
+        WHEN LOWER(@@version_comment) LIKE '%community%' THEN 'community_or_self_managed'
+        ELSE 'mysql_compatible_unknown'
+      END,
+      SUBSTRING_INDEX(@@version, '-', 1);")"; then
+    fail "Performance Schema capability state is unavailable"
+    return 1
+  fi
+  if ! [[ "$state" =~ ^[01]$'\t'[01]$'\t'[01]$'\t'[01]$'\t'[a-z_]+$'\t'[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    fail "Performance Schema capability state is invalid"
+    return 1
+  fi
+
+  privilege_state="not_visible"
+  if grants="$(mysql_scalar "SHOW GRANTS FOR CURRENT_USER;")"; then
+    if grep -Eqi 'ALL PRIVILEGES ON \*\.\*|SYSTEM_VARIABLES_ADMIN' <<<"$grants" \
+      && grep -Eqi 'ALL PRIVILEGES ON \*\.\*|PERSIST_RO_VARIABLES_ADMIN' <<<"$grants"; then
+      privilege_state="visible"
+    fi
+  fi
+
+  local enabled persisted_load x509_configured tls_active server_flavor server_version
+  IFS=$'\t' read -r enabled persisted_load x509_configured tls_active server_flavor server_version <<<"$state"
+  echo "performance schema capability: result=success enabled=$enabled persisted_globals_load=$persisted_load persist_x509_subject_configured=$x509_configured tls_active=$tls_active persist_privileges=$privilege_state server_flavor=$server_flavor server_version=$server_version"
+  if [ "$enabled" = "1" ]; then
+    echo "performance schema capability: next_action=already_enabled restart_required=0"
+  elif [ "$persisted_load" = "1" ] && [ "$x509_configured" = "1" ] && [ "$tls_active" = "1" ] && [ "$privilege_state" = "visible" ]; then
+    echo "performance schema capability: next_action=persist_only_then_controlled_restart restart_required=1"
+  else
+    echo "performance schema capability: next_action=configure_provider_or_server_startup restart_required=1"
+  fi
+}
+
 main() {
   umask 077
   validate_configuration || return 1
@@ -561,6 +607,7 @@ main() {
     restore) restore_database ;;
     status) database_status ;;
     retire-identity-dry-run|retire-identity-apply) retire_identity_tables ;;
+    performance-schema-status) performance_schema_status ;;
   esac
 }
 

--- a/scripts/dbops/database-operation.sh
+++ b/scripts/dbops/database-operation.sh
@@ -558,7 +558,7 @@ performance_schema_status() {
   prepare_defaults_file
   ERROR_PATH="$BACKUP_DIR/.iam_performance_schema_status.error"
 
-  local state grants privilege_state
+  local state grants privilege_state endpoint_provider endpoint_lower
   if ! state="$(mysql_scalar "SELECT
       @@performance_schema + 0,
       @@persisted_globals_load + 0,
@@ -586,9 +586,18 @@ performance_schema_status() {
     fi
   fi
 
+  endpoint_lower="$(tr '[:upper:]' '[:lower:]' <<<"${MYSQL_HOST:-}")"
+  case "$endpoint_lower" in
+    *.mysql.rds.aliyuncs.com|*.rds.aliyuncs.com) endpoint_provider="aliyun_rds" ;;
+    *.rds.amazonaws.com) endpoint_provider="aws_rds" ;;
+    *.cloudsql.googleusercontent.com) endpoint_provider="google_cloud_sql" ;;
+    127.0.0.1|localhost|::1) endpoint_provider="local" ;;
+    *) endpoint_provider="unknown" ;;
+  esac
+
   local enabled persisted_load x509_configured tls_active server_flavor server_version
   IFS=$'\t' read -r enabled persisted_load x509_configured tls_active server_flavor server_version <<<"$state"
-  echo "performance schema capability: result=success enabled=$enabled persisted_globals_load=$persisted_load persist_x509_subject_configured=$x509_configured tls_active=$tls_active persist_privileges=$privilege_state server_flavor=$server_flavor server_version=$server_version"
+  echo "performance schema capability: result=success enabled=$enabled persisted_globals_load=$persisted_load persist_x509_subject_configured=$x509_configured tls_active=$tls_active persist_privileges=$privilege_state server_flavor=$server_flavor endpoint_provider=$endpoint_provider server_version=$server_version"
   if [ "$enabled" = "1" ]; then
     echo "performance schema capability: next_action=already_enabled restart_required=0"
   elif [ "$persisted_load" = "1" ] && [ "$x509_configured" = "1" ] && [ "$tls_active" = "1" ] && [ "$privilege_state" = "visible" ]; then

--- a/scripts/dbops/database-operation.sh
+++ b/scripts/dbops/database-operation.sh
@@ -598,6 +598,31 @@ performance_schema_status() {
   local enabled persisted_load x509_configured tls_active server_flavor server_version
   IFS=$'\t' read -r enabled persisted_load x509_configured tls_active server_flavor server_version <<<"$state"
   echo "performance schema capability: result=success enabled=$enabled persisted_globals_load=$persisted_load persist_x509_subject_configured=$x509_configured tls_active=$tls_active persist_privileges=$privilege_state server_flavor=$server_flavor endpoint_provider=$endpoint_provider server_version=$server_version"
+
+  local table_io_contract table_io_probe table_io_select
+  table_io_contract="unavailable"
+  table_io_select="not_checked"
+  if table_io_probe="$(mysql_scalar "SELECT
+      EXISTS(SELECT 1 FROM information_schema.TABLES
+        WHERE TABLE_SCHEMA = 'performance_schema'
+          AND TABLE_NAME = 'table_io_waits_summary_by_table'),
+      (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = 'performance_schema'
+          AND TABLE_NAME = 'table_io_waits_summary_by_table'
+          AND COLUMN_NAME IN ('COUNT_STAR', 'SUM_TIMER_WAIT', 'COUNT_READ', 'COUNT_WRITE'));" )" \
+      && [ "$table_io_probe" = $'1\t4' ]; then
+    table_io_contract="valid"
+    if table_io_probe="$(mysql_scalar "SELECT COUNT(*) FROM performance_schema.table_io_waits_summary_by_table;")" \
+        && [[ "$table_io_probe" =~ ^[0-9]+$ ]]; then
+      table_io_select="available"
+    else
+      table_io_select="unavailable"
+    fi
+  elif [ -n "$table_io_probe" ]; then
+    table_io_contract="invalid"
+  fi
+  echo "performance schema capability: table_io_contract=$table_io_contract table_io_select=$table_io_select"
+
   if [ "$enabled" = "1" ]; then
     echo "performance schema capability: next_action=already_enabled restart_required=0"
   elif [ "$persisted_load" = "1" ] && [ "$x509_configured" = "1" ] && [ "$tls_active" = "1" ] && [ "$privilege_state" = "visible" ]; then

--- a/scripts/dbops/database_operation_test.go
+++ b/scripts/dbops/database_operation_test.go
@@ -376,6 +376,45 @@ func TestIdentityRetirementRejectsStaleBackup(t *testing.T) {
 	assertSafeOutput(t, output)
 }
 
+func TestPerformanceSchemaStatusIsReadOnlyAndSecretSafe(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	backupDir := filepath.Join(root, "backups")
+	requireNoError(t, os.MkdirAll(bin, 0o700))
+	requireNoError(t, os.MkdirAll(backupDir, 0o700))
+	writeExecutable(t, bin, "mysql", `#!/bin/sh
+if [ "$1" = "--version" ]; then echo 'mysql  Ver 8.0.36'; exit 0; fi
+case "$*" in
+  *"@@performance_schema"*) printf '0\t1\t0\t0\tmanaged_or_cloud\t8.0.36\n' ;;
+  *"SHOW GRANTS"*) printf "GRANT USAGE ON *.* TO 'grant-user-sentinel'@'%%'\n" ;;
+  *) exit 91 ;;
+esac
+`)
+
+	output, err := runScript(t, bin, map[string]string{
+		"IAM_DB_OPS_OPERATION":  "performance-schema-status",
+		"IAM_DB_OPS_BACKUP_DIR": backupDir,
+	})
+	requireNoError(t, err)
+	assertSafeOutput(t, output)
+	for _, want := range []string{
+		"result=success", "enabled=0", "persisted_globals_load=1",
+		"persist_x509_subject_configured=0", "tls_active=0",
+		"persist_privileges=not_visible", "server_flavor=managed_or_cloud",
+		"server_version=8.0.36", "next_action=configure_provider_or_server_startup",
+		"restart_required=1",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("Performance Schema status output missing %q: %s", want, output)
+		}
+	}
+	for _, forbidden := range []string{"grant-user-sentinel", "GRANT USAGE", "SET PERSIST", "RESTART"} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("Performance Schema status output contains forbidden value %q: %s", forbidden, output)
+		}
+	}
+}
+
 func TestStatusFallsBackToOfficialMySQLContainerClient(t *testing.T) {
 	root := t.TempDir()
 	bin := filepath.Join(root, "bin")
@@ -451,6 +490,7 @@ func TestWorkflowUsesSingleCheckedOutScriptAndMySQLIntegration(t *testing.T) {
 		"IAM_DB_OPS_ALLOW_DOCKER_CLIENT", "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
 		"retirement_scope:", "IAM_RETIREMENT_SCOPE",
 		"retire-identity-dry-run", "retire-identity-apply",
+		"performance-schema-status",
 		"IAM_DB_OPS_CONFIRMATION", "confirmation:",
 	} {
 		if !strings.Contains(source, want) {

--- a/scripts/dbops/database_operation_test.go
+++ b/scripts/dbops/database_operation_test.go
@@ -406,7 +406,7 @@ esac
 		"persist_privileges=not_visible", "server_flavor=managed_or_cloud",
 		"endpoint_provider=aliyun_rds",
 		"server_version=8.0.36", "next_action=configure_provider_or_server_startup",
-		"table_io_contract=valid", "table_io_table_exists=1",
+		"table_io_contract=valid", "table_io_metadata_visible=1",
 		"table_io_required_columns=4", "table_io_select=available",
 		"restart_required=1",
 	} {

--- a/scripts/dbops/database_operation_test.go
+++ b/scripts/dbops/database_operation_test.go
@@ -406,7 +406,8 @@ esac
 		"persist_privileges=not_visible", "server_flavor=managed_or_cloud",
 		"endpoint_provider=aliyun_rds",
 		"server_version=8.0.36", "next_action=configure_provider_or_server_startup",
-		"table_io_contract=valid", "table_io_select=available",
+		"table_io_contract=valid", "table_io_table_exists=1",
+		"table_io_required_columns=4", "table_io_select=available",
 		"restart_required=1",
 	} {
 		if !strings.Contains(output, want) {

--- a/scripts/dbops/database_operation_test.go
+++ b/scripts/dbops/database_operation_test.go
@@ -386,6 +386,8 @@ func TestPerformanceSchemaStatusIsReadOnlyAndSecretSafe(t *testing.T) {
 if [ "$1" = "--version" ]; then echo 'mysql  Ver 8.0.36'; exit 0; fi
 case "$*" in
   *"@@performance_schema"*) printf '0\t1\t0\t0\tmanaged_or_cloud\t8.0.36\n' ;;
+  *"information_schema.TABLES"*"table_io_waits_summary_by_table"*) printf '1\t4\n' ;;
+  *"SELECT COUNT(*) FROM performance_schema.table_io_waits_summary_by_table"*) printf '23\n' ;;
   *"SHOW GRANTS"*) printf "GRANT USAGE ON *.* TO 'grant-user-sentinel'@'%%'\n" ;;
   *) exit 91 ;;
 esac
@@ -404,6 +406,7 @@ esac
 		"persist_privileges=not_visible", "server_flavor=managed_or_cloud",
 		"endpoint_provider=aliyun_rds",
 		"server_version=8.0.36", "next_action=configure_provider_or_server_startup",
+		"table_io_contract=valid", "table_io_select=available",
 		"restart_required=1",
 	} {
 		if !strings.Contains(output, want) {

--- a/scripts/dbops/database_operation_test.go
+++ b/scripts/dbops/database_operation_test.go
@@ -394,6 +394,7 @@ esac
 	output, err := runScript(t, bin, map[string]string{
 		"IAM_DB_OPS_OPERATION":  "performance-schema-status",
 		"IAM_DB_OPS_BACKUP_DIR": backupDir,
+		"MYSQL_HOST":            "prod.mysql.rds.aliyuncs.com",
 	})
 	requireNoError(t, err)
 	assertSafeOutput(t, output)
@@ -401,6 +402,7 @@ esac
 		"result=success", "enabled=0", "persisted_globals_load=1",
 		"persist_x509_subject_configured=0", "tls_active=0",
 		"persist_privileges=not_visible", "server_flavor=managed_or_cloud",
+		"endpoint_provider=aliyun_rds",
 		"server_version=8.0.36", "next_action=configure_provider_or_server_startup",
 		"restart_required=1",
 	} {
@@ -408,7 +410,7 @@ esac
 			t.Fatalf("Performance Schema status output missing %q: %s", want, output)
 		}
 	}
-	for _, forbidden := range []string{"grant-user-sentinel", "GRANT USAGE", "SET PERSIST", "RESTART"} {
+	for _, forbidden := range []string{"grant-user-sentinel", "GRANT USAGE", "prod.mysql.rds.aliyuncs.com", "SET PERSIST", "RESTART"} {
 		if strings.Contains(output, forbidden) {
 			t.Fatalf("Performance Schema status output contains forbidden value %q: %s", forbidden, output)
 		}


### PR DESCRIPTION
## What changed

- adds a read-only performance-schema-status database operation
- reports only aggregate capability flags: runtime state, persisted setting loading, TLS/X.509 prerequisites, visible administrative privileges, server flavor classification, and version
- never prints SHOW GRANTS output, account names, connection details, or raw database errors
- routes the operation through the production environment and existing 0600 defaults-file MySQL client mechanism

## Why

Production migration 19 is complete, but migrations 20 and 21 remain blocked because Performance Schema is disabled and the approved fail-closed policy requires instantaneous table I/O evidence. This read-only batch determines whether SQL persistence is possible or provider/server startup configuration is required.

## Validation

- bash -n scripts/dbops/database-operation.sh scripts/dbops/legacy-retirement-preflight.sh
- go test ./scripts/dbops -count=1
- python3 scripts/check-docs-facts.py
- make docs-hygiene

## Release gate

Run performance-schema-status from this branch first. Do not attempt SET PERSIST_ONLY or restart MySQL until the capability output identifies a supported path.