### PR TITLE
feat(migration): retire schema_version in batch 000020

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -174,6 +174,8 @@ MySQL 8 workflow 使用同一脚本执行合成 backup → drop → restore → 
 
 历史表退役证据由 `scripts/dbops/legacy-retirement-preflight.sh`（`make db-retirement-preflight`）只读采集。手动执行 `db-ops.yml` 的 `status` 时会在普通数据库状态检查后运行 format v2 预检，并要求调用者通过 `image_sha` 记录当前生产镜像；`retirement_scope` 可选择 `identity/schema_version/platform/authn/all`，发布时只运行当前批次，避免无关大表对账占用窗口。定时备份、`backup` 和 `restore` 不运行该预检。脚本不执行删表或数据修复，只输出 migration、精确行数、结构指纹、列契约、Performance Schema 生命周期/I/O、依赖计数、旧表到 canonical 表的聚合对账和逐表 eligibility；零 I/O 不能脱离证据窗口解释为“可删除”。
 
+`retirement_io_waiver=platform_tables` 是业务所有者明确批准后的审计开关，只允许 `schema_version/tenants/data_dictionary` 在 Performance Schema 或表 I/O 统计不可用时继续评估。它不能覆盖非零 I/O、dirty migration、版本门禁或数据库对象依赖，也不能用于 AuthN、Identity 或日志/审计表。默认值 `none` 保持 fail closed。
+
 ## server-check.yml
 
 生产健康检查每 30 分钟运行一次，也可手动触发。它运行在 GitHub-hosted Runner 上，目标主机优先使用 `SVRB_PUBLIC_HOST`；只有公网入口未配置时才回退到 `SVRB_HOST` / `SVRA_HOST`。

--- a/.github/workflows/db-ops.yml
+++ b/.github/workflows/db-ops.yml
@@ -39,6 +39,14 @@ on:
           - schema_version
           - platform
           - authn
+      retirement_io_waiver:
+        description: Owner-approved I/O evidence waiver; platform tables only
+        required: false
+        default: none
+        type: choice
+        options:
+          - none
+          - platform_tables
       confirmation:
         description: Exact destructive-operation confirmation token; required for apply only
         required: false
@@ -140,6 +148,7 @@ jobs:
           IAM_RETIREMENT_COMMIT_SHA: ${{ github.sha }}
           IAM_RETIREMENT_IMAGE_SHA: ${{ github.event.inputs.image_sha || 'unknown' }}
           IAM_RETIREMENT_SCOPE: ${{ github.event.inputs.retirement_scope || 'all' }}
+          IAM_RETIREMENT_OWNER_IO_WAIVER: ${{ github.event.inputs.retirement_io_waiver || 'none' }}
           MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
           MYSQL_PORT: ${{ secrets.MYSQL_PORT || 3306 }}
           MYSQL_USERNAME: ${{ secrets.MYSQL_USERNAME }}
@@ -150,7 +159,7 @@ jobs:
           username: ${{ vars.SVRB_USERNAME || vars.SVRA_USERNAME }}
           key: ${{ secrets.SVRB_SSH_KEY || secrets.SVRA_SSH_KEY }}
           port: ${{ vars.SVRB_SSH_PORT || vars.SVRA_SSH_PORT || 22 }}
-          envs: IAM_RETIREMENT_ENVIRONMENT,IAM_RETIREMENT_ALLOW_DOCKER_CLIENT,IAM_RETIREMENT_COMMIT_SHA,IAM_RETIREMENT_IMAGE_SHA,IAM_RETIREMENT_SCOPE,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
+          envs: IAM_RETIREMENT_ENVIRONMENT,IAM_RETIREMENT_ALLOW_DOCKER_CLIENT,IAM_RETIREMENT_COMMIT_SHA,IAM_RETIREMENT_IMAGE_SHA,IAM_RETIREMENT_SCOPE,IAM_RETIREMENT_OWNER_IO_WAIVER,MYSQL_HOST,MYSQL_PORT,MYSQL_USERNAME,MYSQL_PASSWORD,MYSQL_DBNAME
           script_path: scripts/dbops/legacy-retirement-preflight.sh
 
   db-controlled-operation:

--- a/internal/pkg/migration/MIGRATION_GUIDE.md
+++ b/internal/pkg/migration/MIGRATION_GUIDE.md
@@ -1,248 +1,26 @@
-# 数据库迁移文档
+# 数据库迁移入口
 
-## 概述
+> 状态：当前入口。旧版 guide 使用不存在的 `iam_*` 表名、失效 Make target 和过时 AuthN 模型，已于 2026-08-07 退役；不要从 Git 历史复制其中的 SQL 执行。
 
-本项目使用 [golang-migrate](https://github.com/golang-migrate/migrate) 进行数据库版本管理和迁移。
+IAM 使用 `golang-migrate`。Schema 的唯一事实源是同目录 `migrations/*.sql`，由 `migrate.go` 通过 `embed.FS` 加载，版本和 dirty 状态只记录在 `schema_migrations`。
 
-## 迁移文件列表
+## 当前规则
 
-### 000001_init_schema
+- 已发布 migration 不原地修改；修复只新增 forward 版本。
+- 应用启动负责执行 migration；没有当前 `make db-migrate`、`make db-version` 或 `make db-rollback` 入口。
+- `configs/mysql/bootstrap.sql` 只在 schema 达到当前版本后写幂等系统基线数据，不创建表，也不能替代 migration。
+- destructive down 不提供虚假空表回滚；`000019–000020` 明确 fail closed，恢复依赖已验证备份。
+- 历史表退役必须先执行 secret-safe 只读 preflight，仓库 migration 存在不等于目标库已经执行。
 
-**版本**: 1  
-**日期**: 2025-10-31  
-**描述**: 初始化数据库 Schema，包含所有模块的表结构
+## 权威文档
 
-**包含的模块**:
+- 当前迁移和发布机制：`docs/05-工程质量与运维/03-迁移发布与数据库运维.md`
+- MySQL 与事务边界：`docs/03-基础设施/01-MySQL事务与迁移.md`
+- 遗留表退役台账：`docs/05-工程质量与运维/06-遗留资产兼容层与数据库退役审计.md`
 
-- Identity - 身份域
-- Authentication (Authn) - 认证模块
-- Authorization (Authz) - 授权模块
-- Identity Provider (IDP) - 身份提供商
-- Platform / System - 平台系统表
-
-**主要表**:
-
-- `iam_users` - 用户表
-- `iam_profiles` - 儿童档案表
-- `iam_refs` - 监护关系表
-- `iam_auth_accounts` - 认证账号表（旧版）
-- `iam_auth_wechat_accounts` - 微信账号扩展表（旧版）
-- `iam_auth_operation_accounts` - 运营账号凭证表（旧版）
-- `iam_jwks_keys` - JWKS 密钥表
-- `iam_authz_*` - 授权相关表
-- 其他系统表
-
-### 000002_refactor_authn_schema
-
-**版本**: 2.1  
-**日期**: 2025-11-05  
-**描述**: 重构认证模块表结构，使其符合领域驱动设计（DDD）
-
-**主要变更**:
-
-1. **统一账户表** (`iam_authn_accounts`)
-   - 替代旧的 `iam_auth_accounts` + `iam_auth_wechat_accounts`
-   - 统一管理所有类型的第三方登录账户
-   - 账户类型: `wc-minip`（微信小程序）, `wc-offi`（微信公众号）, `wc-com`（企业微信）, `opera`（运营后台）
-   - 字段说明:
-     - `type`: 账户类型
-     - `app_id`: 应用ID（微信 appid、企业微信 corpid、运营后台为空）
-     - `external_id`: 外部平台用户标识（openid、userid、username）
-     - `unique_id`: 全局唯一标识（unionid、运营后台为空）
-     - `profile`: 用户资料（JSON格式：昵称、头像等）
-     - `meta`: 额外元数据（JSON格式）
-     - `status`: 账户状态（0-禁用, 1-激活, 2-归档, 3-删除）
-
-2. **统一凭据表** (`iam_authn_credentials`)
-   - 替代旧的 `iam_auth_operation_accounts`
-   - 统一管理所有类型的认证凭据
-   - 凭据类型: `password`, `phone_otp`, `oauth_wx_minip`, `oauth_wecom`
-   - 字段说明:
-     - `account_id`: 关联账户ID
-     - `type`: 凭据类型
-     - `idp`: IDP类型（wechat、wecom、phone、NULL）
-     - `idp_identifier`: IDP标识符（unionid、openid@appid、userid、+E164、空）
-     - `app_id`: 应用ID（wechat=appid、wecom=corpid、NULL）
-     - `material`: 凭据材料（PHC哈希格式的密码、其他类型为NULL）
-     - `algo`: 算法（argon2id、bcrypt、NULL）
-     - `params_json`: 参数JSON（微信 profile、企业微信 agentid 等）
-     - `status`: 凭据状态（0-禁用, 1-启用）
-     - `failed_attempts`: 失败尝试次数（仅 password）
-     - `locked_until`: 锁定截止时间（仅 password）
-
-3. **Token 审计表** (`iam_authn_token_audit`)
-   - 替代旧的 `iam_auth_sessions` + `iam_auth_revoked_access_token`
-   - Token 主存储迁移到 Redis，表仅用于审计和长期追踪
-   - 记录 Token 签发和撤销历史
-
-**删除的表**:
-
-- `iam_auth_accounts` (已合并到 `iam_authn_accounts`)
-- `iam_auth_wechat_accounts` (已合并到 `iam_authn_accounts`)
-- `iam_auth_operation_accounts` (已合并到 `iam_authn_credentials`)
-- `iam_auth_sessions` (Token 迁移到 Redis)
-- `iam_auth_revoked_access_token` (合并到 `iam_authn_token_audit`)
-
-**设计优势**:
-
-- ✅ 符合领域驱动设计原则
-- ✅ 统一的账户和凭据管理
-- ✅ 支持多种认证方式（密码、OTP、OAuth）
-- ✅ 灵活的扩展性（通过 JSON 字段）
-- ✅ 性能优化（Redis 存储 Token）
-- ✅ 完整的审计追踪
-
-## 使用方法
-
-### 查看当前版本
+验证当前迁移合同：
 
 ```bash
-make db-version
+go test ./internal/pkg/migration -count=1
+python3 scripts/check-docs-facts.py
 ```
-
-### 执行迁移（升级到最新版本）
-
-```bash
-make db-migrate
-```
-
-### 回滚一个版本
-
-```bash
-make db-rollback
-```
-
-### 回滚到指定版本
-
-```bash
-migrate -path internal/pkg/migration/migrations \
-        -database "mysql://user:pass@tcp(host:port)/dbname" \
-        goto 1
-```
-
-## 数据迁移注意事项
-
-### 从 v1 升级到 v2
-
-⚠️ **重要**: 本迁移会删除旧表中的所有数据！
-
-**生产环境迁移步骤**:
-
-1. **备份数据库**
-
-   ```bash
-   mysqldump -u root -p iam > backup_before_v2.sql
-   ```
-
-2. **准备数据迁移脚本**（如果需要保留数据）
-
-   ```sql
-   -- 迁移账户数据示例
-   INSERT INTO iam_authn_accounts (id, user_id, type, app_id, external_id, unique_id, status, created_at, updated_at)
-   SELECT 
-       a.id,
-       a.user_id,
-       CASE a.provider
-           WHEN 'wechat' THEN 'wc-minip'
-           WHEN 'operation' THEN 'opera'
-           ELSE a.provider
-       END as type,
-       COALESCE(a.app_id, '') as app_id,
-       a.external_id,
-       COALESCE(w.union_id, '') as unique_id,
-       a.status,
-       a.created_at,
-       a.updated_at
-   FROM iam_auth_accounts a
-   LEFT JOIN iam_auth_wechat_accounts w ON a.id = w.account_id;
-   
-   -- 迁移凭据数据示例
-   INSERT INTO iam_authn_credentials (account_id, type, idp, idp_identifier, material, algo, status, created_at, updated_at)
-   SELECT 
-       o.account_id,
-       'password',
-       NULL,
-       '',
-       o.password_hash,
-       o.algo,
-       1,
-       o.created_at,
-       o.updated_at
-   FROM iam_auth_operation_accounts o;
-   ```
-
-3. **在测试环境验证迁移**
-
-   ```bash
-   # 测试环境执行迁移
-   make db-migrate
-   
-   # 验证数据完整性
-   # 验证应用功能正常
-   ```
-
-4. **生产环境执行**
-   - 选择低峰时段
-   - 准备回滚方案
-   - 监控迁移过程
-   - 验证数据和功能
-
-5. **如需回滚**
-
-   ```bash
-   make db-rollback
-   # 或恢复备份
-   mysql -u root -p iam < backup_before_v2.sql
-   ```
-
-## 迁移文件命名规范
-
-```text
-{version}_{description}.{up|down}.sql
-```
-
-- `version`: 迁移版本号（6位数字，如 000001, 000002）
-- `description`: 迁移描述（小写字母+下划线）
-- `up`: 升级脚本
-- `down`: 降级/回滚脚本
-
-## 最佳实践
-
-1. **每次迁移前备份数据库**
-2. **先在测试环境验证**
-3. **编写详细的迁移说明**
-4. **确保 up 和 down 脚本成对存在**
-5. **避免在迁移中修改数据**（如需修改，单独编写数据迁移脚本）
-6. **使用事务（如果数据库支持）**
-7. **迁移后验证数据完整性**
-
-## 故障排查
-
-### 迁移失败（dirty state）
-
-```bash
-# 查看当前版本和状态
-make db-version
-
-# 手动修复（假设失败在版本 2）
-migrate -path internal/pkg/migration/migrations \
-        -database "mysql://user:pass@tcp(host:port)/dbname" \
-        force 2
-
-# 重新执行迁移
-make db-migrate
-```
-
-### 回滚后恢复数据
-
-如果回滚后需要恢复数据，使用之前的备份：
-
-```bash
-mysql -u root -p iam < backup_before_v2.sql
-```
-
-## 相关文档
-
-- [golang-migrate 官方文档](https://github.com/golang-migrate/migrate)
-- [数据库设计文档](../../docs/authn/)
-- [领域模型文档](../../internal/apiserver/domain/authn/)

--- a/internal/pkg/migration/migrations/000020_retire_schema_version.down.sql
+++ b/internal/pkg/migration/migrations/000020_retire_schema_version.down.sql
@@ -1,0 +1,3 @@
+-- schema_version is redundant metadata with no lossless inverse after removal.
+SIGNAL SQLSTATE '45000'
+    SET MESSAGE_TEXT = '000020 schema_version retirement is irreversible; restore a verified backup instead';

--- a/internal/pkg/migration/migrations/000020_retire_schema_version.up.sql
+++ b/internal/pkg/migration/migrations/000020_retire_schema_version.up.sql
@@ -1,0 +1,69 @@
+-- Retire the redundant schema_version table. golang-migrate owns the canonical
+-- schema state in schema_migrations; database-owned dependencies still fail
+-- closed before the final irreversible removal.
+
+SET @iam_retirement_pattern =
+    '(^|[^a-z0-9_])(schema_version)([^a-z0-9_]|$)';
+SET @iam_retirement_dependencies = (
+      SELECT COUNT(*)
+      FROM information_schema.KEY_COLUMN_USAGE
+      WHERE (
+          TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'schema_version'
+          AND REFERENCED_TABLE_NAME IS NOT NULL
+      )
+      OR (
+          REFERENCED_TABLE_SCHEMA = DATABASE()
+          AND REFERENCED_TABLE_NAME = 'schema_version'
+      )
+)
++ (
+      SELECT COUNT(*)
+      FROM information_schema.TRIGGERS
+      WHERE TRIGGER_SCHEMA = DATABASE()
+        AND (
+            EVENT_OBJECT_TABLE = 'schema_version'
+            OR LOWER(ACTION_STATEMENT) REGEXP @iam_retirement_pattern
+        )
+)
++ (
+      SELECT COUNT(*)
+      FROM information_schema.VIEWS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND (
+            VIEW_DEFINITION IS NULL
+            OR LOWER(VIEW_DEFINITION) REGEXP @iam_retirement_pattern
+        )
+)
++ (
+      SELECT COUNT(*)
+      FROM information_schema.ROUTINES
+      WHERE ROUTINE_SCHEMA = DATABASE()
+        AND (
+            ROUTINE_DEFINITION IS NULL
+            OR LOWER(ROUTINE_DEFINITION) REGEXP @iam_retirement_pattern
+        )
+)
++ (
+      SELECT COUNT(*)
+      FROM information_schema.EVENTS
+      WHERE EVENT_SCHEMA = DATABASE()
+        AND (
+            EVENT_DEFINITION IS NULL
+            OR LOWER(EVENT_DEFINITION) REGEXP @iam_retirement_pattern
+        )
+);
+
+DROP TEMPORARY TABLE IF EXISTS iam_schema_version_retirement_assertion;
+CREATE TEMPORARY TABLE iam_schema_version_retirement_assertion
+(
+    message VARCHAR(128) NOT NULL PRIMARY KEY
+);
+INSERT INTO iam_schema_version_retirement_assertion (message)
+VALUES ('schema_version database dependencies still exist');
+INSERT INTO iam_schema_version_retirement_assertion (message)
+SELECT 'schema_version database dependencies still exist'
+WHERE @iam_retirement_dependencies <> 0;
+DROP TEMPORARY TABLE iam_schema_version_retirement_assertion;
+
+DROP TABLE IF EXISTS schema_version;

--- a/internal/pkg/migration/retire_schema_version_contract_test.go
+++ b/internal/pkg/migration/retire_schema_version_contract_test.go
@@ -1,0 +1,31 @@
+package migration
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSchemaVersionRetirementMigrationIsScopedAndFailClosed(t *testing.T) {
+	up := migrationSQL(t, "000020_retire_schema_version.up.sql")
+	assertSQLInOrder(t, up,
+		"information_schema.KEY_COLUMN_USAGE",
+		"information_schema.TRIGGERS",
+		"information_schema.VIEWS",
+		"information_schema.ROUTINES",
+		"information_schema.EVENTS",
+		"iam_schema_version_retirement_assertion",
+		"DROP TABLE IF EXISTS schema_version",
+	)
+	for _, outOfScope := range []string{
+		"auth_accounts", "auth_credentials_legacy", "tenants", "data_dictionary",
+		"operation_logs", "audit_logs", "auth_token_audit",
+	} {
+		assertSQLNotContains(t, up, outOfScope)
+	}
+	if strings.Count(up, "DROP TABLE IF EXISTS") != 1 {
+		t.Fatalf("schema_version retirement must use one final DROP statement")
+	}
+	down := migrationSQL(t, "000020_retire_schema_version.down.sql")
+	assertSQLContains(t, down, "SIGNAL SQLSTATE '45000'")
+	assertSQLContains(t, down, "irreversible")
+}

--- a/internal/pkg/migration/retire_schema_version_mysql_test.go
+++ b/internal/pkg/migration/retire_schema_version_mysql_test.go
@@ -1,0 +1,57 @@
+package migration
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+func TestRetireSchemaVersionMigrationMySQL(t *testing.T) {
+	db := openMigrationMySQL(t)
+	up := migrationSQL(t, "000020_retire_schema_version.up.sql")
+	down := migrationSQL(t, "000020_retire_schema_version.down.sql")
+	t.Cleanup(func() { resetSchemaVersionRetirementFixture(t, db) })
+
+	t.Run("drops the redundant table and tolerates an absent table", func(t *testing.T) {
+		resetSchemaVersionRetirementFixture(t, db)
+		mustExecMigrationSQL(t, db, `CREATE TABLE schema_version (
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  version VARCHAR(20) NOT NULL
+); INSERT INTO schema_version (version) VALUES ('legacy')`)
+
+		mustExecMigrationSQL(t, db, up)
+		assertTableExists(t, db, "schema_version", false)
+		mustExecMigrationSQL(t, db, up)
+	})
+
+	t.Run("dependency aborts before removal", func(t *testing.T) {
+		resetSchemaVersionRetirementFixture(t, db)
+		mustExecMigrationSQL(t, db, `CREATE TABLE schema_version (
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  version VARCHAR(20) NOT NULL
+); CREATE VIEW legacy_schema_version_view AS SELECT id FROM schema_version`)
+
+		if _, err := db.Exec(up); err == nil || !strings.Contains(err.Error(), "schema_version database dependencies still exist") {
+			t.Fatalf("migration error = %v, want dependency failure", err)
+		}
+		assertTableExists(t, db, "schema_version", true)
+	})
+
+	t.Run("down fails closed", func(t *testing.T) {
+		if _, err := db.Exec(down); err == nil || !strings.Contains(err.Error(), "irreversible") {
+			t.Fatalf("down migration error = %v, want irreversible failure", err)
+		}
+	})
+}
+
+func resetSchemaVersionRetirementFixture(t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, statement := range []string{
+		"DROP VIEW IF EXISTS legacy_schema_version_view",
+		"DROP TABLE IF EXISTS schema_version",
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("reset schema_version retirement fixture with %q: %v", statement, err)
+		}
+	}
+}

--- a/scripts/check-docs-facts.py
+++ b/scripts/check-docs-facts.py
@@ -71,8 +71,8 @@ def check_migrations() -> None:
     }
     if up != down:
         fail(f"migration up/down numbers differ: up-only={sorted(up-down)} down-only={sorted(down-up)}")
-    if not up or max(up) != 19:
-        fail(f"documented latest migration is 19, repository has {max(up) if up else 'none'}")
+    if not up or max(up) != 20:
+        fail(f"documented latest migration is 20, repository has {max(up) if up else 'none'}")
     migration = (directory / "000016_jwks_single_active_guard.up.sql").read_text(encoding="utf-8")
     for token in ("active_guard", "uk_jwks_keys_single_active"):
         if token not in migration:
@@ -370,6 +370,8 @@ def check_database_operations_facts() -> None:
         "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
         "retirement_scope:",
         "IAM_RETIREMENT_SCOPE",
+        "retirement_io_waiver:",
+        "IAM_RETIREMENT_OWNER_IO_WAIVER",
         "retire-identity-dry-run",
         "retire-identity-apply",
         "performance-schema-status",
@@ -422,6 +424,8 @@ def check_database_operations_facts() -> None:
         "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
         "mysql:8.0",
         "IAM_RETIREMENT_SCOPE",
+        "IAM_RETIREMENT_OWNER_IO_WAIVER",
+        "owner_io_waiver_allows",
         "schema_contract",
     ):
         if token not in retirement:

--- a/scripts/dbops/database_operation_test.go
+++ b/scripts/dbops/database_operation_test.go
@@ -495,6 +495,7 @@ func TestWorkflowUsesSingleCheckedOutScriptAndMySQLIntegration(t *testing.T) {
 		"image_sha:", "IAM_RETIREMENT_IMAGE_SHA", "Run Legacy Retirement Preflight",
 		"IAM_DB_OPS_ALLOW_DOCKER_CLIENT", "IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
 		"retirement_scope:", "IAM_RETIREMENT_SCOPE",
+		"retirement_io_waiver:", "IAM_RETIREMENT_OWNER_IO_WAIVER",
 		"retire-identity-dry-run", "retire-identity-apply",
 		"performance-schema-status",
 		"IAM_DB_OPS_CONFIRMATION", "confirmation:",

--- a/scripts/dbops/legacy-retirement-preflight.sh
+++ b/scripts/dbops/legacy-retirement-preflight.sh
@@ -10,6 +10,7 @@ SUPPLIED_DEFAULTS="${IAM_RETIREMENT_MYSQL_DEFAULTS_FILE:-}"
 ALLOW_DOCKER_CLIENT="${IAM_RETIREMENT_ALLOW_DOCKER_CLIENT:-0}"
 MYSQL_CLIENT_IMAGE="${IAM_RETIREMENT_MYSQL_CLIENT_IMAGE:-mysql:8.0}"
 RETIREMENT_SCOPE="${IAM_RETIREMENT_SCOPE:-all}"
+OWNER_IO_WAIVER="${IAM_RETIREMENT_OWNER_IO_WAIVER:-none}"
 
 MYSQL_DEFAULTS=""
 ERROR_PATH=""
@@ -132,6 +133,10 @@ validate_configuration() {
   case "$RETIREMENT_SCOPE" in
     all|identity|schema_version|platform|authn) ;;
     *) fail "retirement scope is invalid"; return 1 ;;
+  esac
+  case "$OWNER_IO_WAIVER" in
+    none|platform_tables) ;;
+    *) fail "owner I/O waiver is invalid"; return 1 ;;
   esac
   if ! [[ "$MYSQL_DBNAME" =~ ^[A-Za-z0-9_]+$ ]]; then
     fail "database name is invalid"
@@ -548,22 +553,29 @@ common_retirement_blocker() {
     return
   fi
   if [ "$PERFORMANCE_ENABLED" != "1" ]; then
-    printf 'performance_schema_unavailable'
-    return
-  fi
-  io_line="$(awk -F '\t' -v wanted="$table" '$1 == wanted { print; exit }' "$IO_CACHE_PATH")"
-  if [ -z "$io_line" ]; then
-    printf 'table_io_unavailable'
-    return
-  fi
-  IFS=$'\t' read -r _ io_state reads writes <<<"$io_line"
-  if [ "$io_state" != "available" ]; then
-    printf 'table_io_unavailable'
-    return
-  fi
-  if [ "$reads" != "0" ] || [ "$writes" != "0" ]; then
-    printf 'instantaneous_io_nonzero'
-    return
+    if ! owner_io_waiver_allows "$table"; then
+      printf 'performance_schema_unavailable'
+      return
+    fi
+  else
+    io_line="$(awk -F '\t' -v wanted="$table" '$1 == wanted { print; exit }' "$IO_CACHE_PATH")"
+    if [ -z "$io_line" ]; then
+      if ! owner_io_waiver_allows "$table"; then
+        printf 'table_io_unavailable'
+        return
+      fi
+    else
+      IFS=$'\t' read -r _ io_state reads writes <<<"$io_line"
+      if [ "$io_state" != "available" ]; then
+        if ! owner_io_waiver_allows "$table"; then
+          printf 'table_io_unavailable'
+          return
+        fi
+      elif [ "$reads" != "0" ] || [ "$writes" != "0" ]; then
+        printf 'instantaneous_io_nonzero'
+        return
+      fi
+    fi
   fi
   dependency_line="$(awk -F '\t' -v wanted="$table" '$1 == wanted { print; exit }' "$DEPENDENCY_CACHE_PATH")"
   if [ -z "$dependency_line" ]; then
@@ -584,10 +596,40 @@ common_retirement_blocker() {
   fi
 }
 
+owner_io_waiver_allows() {
+  local table="$1"
+  [ "$OWNER_IO_WAIVER" = "platform_tables" ] \
+    && [[ " schema_version tenants data_dictionary " == *" $table "* ]]
+}
+
+io_evidence_mode() {
+  local table="$1"
+  local io_line io_state
+  if ! owner_io_waiver_allows "$table"; then
+    printf 'instantaneous'
+    return
+  fi
+  if [ "$PERFORMANCE_ENABLED" != "1" ]; then
+    printf 'owner_io_waiver'
+    return
+  fi
+  io_line="$(awk -F '\t' -v wanted="$table" '$1 == wanted { print; exit }' "$IO_CACHE_PATH")"
+  if [ -z "$io_line" ]; then
+    printf 'owner_io_waiver'
+    return
+  fi
+  IFS=$'\t' read -r _ io_state _ _ <<<"$io_line"
+  if [ "$io_state" != "available" ]; then
+    printf 'owner_io_waiver'
+  else
+    printf 'instantaneous'
+  fi
+}
+
 emit_simple_eligibility() {
   local table="$1"
   local repository_gate="$2"
-  local present blocker
+  local present blocker evidence
   present="$(table_present "$table")"
   if [ "$present" != "1" ]; then
     printf 'eligibility\t%s\tstate=already_absent\tevidence=instantaneous\n' "$table"
@@ -598,8 +640,9 @@ emit_simple_eligibility() {
     printf 'eligibility\t%s\tstate=blocked\treason=%s\tevidence=instantaneous\n' "$table" "$blocker"
     return
   fi
-  printf 'eligibility\t%s\tstate=eligible\trepository_gate=%s\tevidence=instantaneous\n' \
-    "$table" "$repository_gate"
+  evidence="$(io_evidence_mode "$table")"
+  printf 'eligibility\t%s\tstate=eligible\trepository_gate=%s\tevidence=%s\n' \
+    "$table" "$repository_gate" "$evidence"
 }
 
 emit_auth_account_eligibility() {
@@ -733,7 +776,8 @@ main() {
   chmod 0600 "$ERROR_PATH"
   chmod 0600 "$IO_CACHE_PATH" "$DEPENDENCY_CACHE_PATH" "$PARITY_CACHE_PATH"
 
-  printf 'legacy_retirement_preflight\tformat_version=2\tquery_mode=read_only_aggregate\tscope=%s\n' "$RETIREMENT_SCOPE"
+  printf 'legacy_retirement_preflight\tformat_version=2\tquery_mode=read_only_aggregate\tscope=%s\towner_io_waiver=%s\n' \
+    "$RETIREMENT_SCOPE" "$OWNER_IO_WAIVER"
   emit_metadata
   emit_migration_state
   emit_candidate_tables

--- a/scripts/dbops/legacy_retirement_preflight_test.go
+++ b/scripts/dbops/legacy_retirement_preflight_test.go
@@ -43,6 +43,8 @@ func TestLegacyRetirementPreflightIsReadOnlyAndCoversRetirementEvidence(t *testi
 		"IAM_RETIREMENT_ALLOW_DOCKER_CLIENT",
 		"mysql:8.0",
 		"IAM_RETIREMENT_SCOPE",
+		"IAM_RETIREMENT_OWNER_IO_WAIVER",
+		"owner_io_waiver_allows",
 		"schema_contract",
 	} {
 		if !strings.Contains(source, required) {
@@ -95,7 +97,10 @@ case "$*" in
   *"MAX(TABLE_ROWS)"*) printf "1\t4\t4096\t2026-08-06T00:00:00Z\n" ;;
   *"@@performance_schema"*) printf "1\n" ;;
   *"performance_schema.global_status"*) printf "86400\n" ;;
-  *"table_io_waits_summary_by_table"*) printf "0\t0\t${FAKE_IO_READS:-0}\t0\n" ;;
+  *"table_io_waits_summary_by_table"*)
+    [ "${FAKE_IO_UNAVAILABLE:-0}" = "1" ] && exit 82
+    printf "0\t0\t${FAKE_IO_READS:-0}\t0\n"
+    ;;
   *"information_schema.KEY_COLUMN_USAGE"*) printf "0\t0\t0\t0\t0\t0\t0\t0\n" ;;
   *"TABLE_NAME = 'auth_credentials' AND COLUMN_NAME = 'account_id'"*) printf "0\n" ;;
   *"information_schema.COLUMNS"*) printf "12\t0123456789abcdef\n" ;;
@@ -171,12 +176,50 @@ esac
 	}
 
 	ioCmd := exec.Command("/bin/bash", script)
-	ioCmd.Env = append(cmd.Env, "FAKE_IO_READS=1")
+	ioCmd.Env = append(cmd.Env, "FAKE_IO_READS=1", "IAM_RETIREMENT_OWNER_IO_WAIVER=platform_tables")
 	ioOutput, err := ioCmd.CombinedOutput()
 	requireNoError(t, err)
 	assertSafeOutput(t, string(ioOutput))
 	if !strings.Contains(string(ioOutput), "eligibility\tschema_version\tstate=blocked\treason=instantaneous_io_nonzero") {
 		t.Fatalf("nonzero I/O did not fail eligibility closed:\n%s", ioOutput)
+	}
+
+	unavailableCmd := exec.Command("/bin/bash", script)
+	unavailableCmd.Env = append(cmd.Env,
+		"FAKE_IO_UNAVAILABLE=1",
+		"IAM_RETIREMENT_SCOPE=schema_version",
+	)
+	unavailableOutput, err := unavailableCmd.CombinedOutput()
+	requireNoError(t, err)
+	assertSafeOutput(t, string(unavailableOutput))
+	if !strings.Contains(string(unavailableOutput), "eligibility\tschema_version\tstate=blocked\treason=table_io_unavailable") {
+		t.Fatalf("unavailable I/O without waiver did not fail closed:\n%s", unavailableOutput)
+	}
+
+	waiverCmd := exec.Command("/bin/bash", script)
+	waiverCmd.Env = append(cmd.Env,
+		"FAKE_IO_UNAVAILABLE=1",
+		"IAM_RETIREMENT_SCOPE=schema_version",
+		"IAM_RETIREMENT_OWNER_IO_WAIVER=platform_tables",
+	)
+	waiverOutput, err := waiverCmd.CombinedOutput()
+	requireNoError(t, err)
+	assertSafeOutput(t, string(waiverOutput))
+	if !strings.Contains(string(waiverOutput), "eligibility\tschema_version\tstate=eligible\trepository_gate=retire_schema_version\tevidence=owner_io_waiver") {
+		t.Fatalf("owner waiver did not admit schema_version with unavailable I/O:\n%s", waiverOutput)
+	}
+
+	authnWaiverCmd := exec.Command("/bin/bash", script)
+	authnWaiverCmd.Env = append(cmd.Env,
+		"FAKE_IO_UNAVAILABLE=1",
+		"IAM_RETIREMENT_SCOPE=authn",
+		"IAM_RETIREMENT_OWNER_IO_WAIVER=platform_tables",
+	)
+	authnWaiverOutput, err := authnWaiverCmd.CombinedOutput()
+	requireNoError(t, err)
+	assertSafeOutput(t, string(authnWaiverOutput))
+	if !strings.Contains(string(authnWaiverOutput), "eligibility\tauth_accounts\tstate=blocked\treason=table_io_unavailable") {
+		t.Fatalf("platform waiver unexpectedly admitted AuthN:\n%s", authnWaiverOutput)
 	}
 
 	identityCmd := exec.Command("/bin/bash", script)


### PR DESCRIPTION
## What changed

- add forward-only migration 000020 to retire only `schema_version`
- fail closed on FK, trigger, view, routine, event, or opaque database definitions
- add an explicit owner-approved I/O-unavailable waiver limited to platform tables
- keep nonzero I/O, dirty migrations, dependency failures, AuthN, and audit tables blocked
- retire the stale migration guide and point to current source-of-truth documentation

## Why

`schema_migrations` is the canonical migration ledger. The owner approved deleting the redundant empty `schema_version` table and accepted the residual risk from unavailable Performance Schema table-I/O evidence.

## Validation

- `bash -n scripts/dbops/legacy-retirement-preflight.sh`
- `go test ./scripts/dbops ./internal/pkg/migration -count=1`
- `python3 scripts/check-docs-facts.py`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

All commands were run from a clean worktree at commit `370b8a09`. Migration 000021, bootstrap changes, AuthN tables, and log/audit tables are excluded from this PR.